### PR TITLE
fix In-page link

### DIFF
--- a/docs/installation/Setup-OpenFunction-Serving-with-Knative.md
+++ b/docs/installation/Setup-OpenFunction-Serving-with-Knative.md
@@ -109,7 +109,7 @@ eventing-controller-d666b4657-jwsrk    1/1     Running   0          23m
 eventing-webhook-778b6b8cf4-mgjtr      1/1     Running   0          23m
 ```
 
-## Installation with poor network connections to GitHub/Googleapis
+## Installation when having poor network connectivity to GitHub/Googleapis
 
 ### Install Knative CLI
 


### PR DESCRIPTION
1. Change the In-page link destination title to ```Installation when having poor network connectivity to GitHub/Googleapis```

for issue #13 
Signed-off-by: laminar <fangtian@yunify.com>