### PR TITLE
expose the 'gitInitImage' configuration item

### DIFF
--- a/config/samples/core_v1alpha1_function.yaml
+++ b/config/samples/core_v1alpha1_function.yaml
@@ -15,6 +15,7 @@ spec:
   source:
     url: "https://github.com/OpenFunction/function-samples.git"
     sourceSubPath: "hello-world-go"
+    gitInitImage: ""
   image: "openfunction/sample-go-func:latest"
   registry:
     url: "https://index.docker.io/v1/"

--- a/pkg/controllers/build.go
+++ b/pkg/controllers/build.go
@@ -29,6 +29,7 @@ const (
 	buildTask             = "build"
 	gitCloneTask          = "git-clone"
 	url                   = "url"
+	gitInitImage          = "gitInitImage"
 	cacheWorkspace        = "cache-ws"
 	sourceWorkspace       = "shared-ws"
 	output                = "output"
@@ -250,6 +251,13 @@ func (r *BuilderReconciler) mutatePipeline(p *pipeline.Pipeline, builder *openfu
 					Value: pipeline.ArrayOrString{
 						Type:      pipeline.ParamTypeString,
 						StringVal: builder.Spec.Source.Url,
+					},
+				},
+				pipeline.Param{
+					Name: gitInitImage,
+					Value: pipeline.ArrayOrString{
+						Type:      pipeline.ParamTypeString,
+						StringVal: *builder.Spec.Source.GitInitImage,
 					},
 				},
 			},


### PR DESCRIPTION
1. By exposing the "gitInitImage" configuration item, the ```Builder``` can control the "gitInitImage" parameter of the ```git-clone``` task.
2. Modified the configuration in sample ```core_v1alpha1_function.yaml``` to add the ```spec.source.gitInitImage``` property. If Tekton is used as the Builder, leaving this empty means useing the default image which is named: ```gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0``` while you can use another image instead of it.

Signed-off-by: laminar <fangtian@yunify.com>