### PR TITLE
1. Un-expose the gitInitImage parameter and change default value to "…

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,7 @@ If you have already installed the OpenFunction platform, follow the steps below 
    > When having poor network connectivity to GitHub/Googleapis, follow these changes:
    > 
    > ```spec.builder``` : "openfunction/buildpacks-builder:v1"
-   > 
-   > ```spec.source.gitInitImage``` : "openfunction/tektoncd-pipeline-cmd-git-init:v0.21.0"
-   
+
     Use the following command to create this Function:
 
     ```shell

--- a/pkg/controllers/build.go
+++ b/pkg/controllers/build.go
@@ -29,7 +29,6 @@ const (
 	buildTask             = "build"
 	gitCloneTask          = "git-clone"
 	url                   = "url"
-	gitInitImage          = "gitInitImage"
 	cacheWorkspace        = "cache-ws"
 	sourceWorkspace       = "shared-ws"
 	output                = "output"
@@ -251,13 +250,6 @@ func (r *BuilderReconciler) mutatePipeline(p *pipeline.Pipeline, builder *openfu
 					Value: pipeline.ArrayOrString{
 						Type:      pipeline.ParamTypeString,
 						StringVal: builder.Spec.Source.Url,
-					},
-				},
-				pipeline.Param{
-					Name: gitInitImage,
-					Value: pipeline.ArrayOrString{
-						Type:      pipeline.ParamTypeString,
-						StringVal: *builder.Spec.Source.GitInitImage,
 					},
 				},
 			},

--- a/pkg/controllers/build_task_templates.go
+++ b/pkg/controllers/build_task_templates.go
@@ -247,7 +247,7 @@ spec:
     - name: gitInitImage
       description: the image used where the git-init binary is
       type: string
-      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0"
+      default: "openfunction/tektoncd-pipeline-cmd-git-init:v0.21.0"
   results:
     - name: commit
       description: The precise commit SHA that was fetched by this Task


### PR DESCRIPTION
1. Un-expose the ```gitInitImage``` parameter and change default value to ```openfunction/tektoncd-pipeline-cmd-git-init:v0.21.0```.

Signed-off-by: laminar <fangtian@yunify.com>