### PR TITLE
Add FuncSource parameter

### DIFF
--- a/config/bundle.yaml
+++ b/config/bundle.yaml
@@ -50,6 +50,9 @@ spec:
               funcType:
                 description: Function type such as HTTP or CloudEvent
                 type: string
+              funcSource:
+                description: Function source such as main.py for python
+                type: string
               funcVersion:
                 description: Function version in format like v1.0.0
                 type: string
@@ -222,6 +225,9 @@ spec:
                 type: string
               funcType:
                 description: Function type such as HTTP or CloudEvent
+                type: string
+              funcSource:
+                description: FuncSource source such as main.py for python
                 type: string
               funcVersion:
                 description: Function version in format like v1.0.0

--- a/config/crd/bases/core.openfunction.io_builders.yaml
+++ b/config/crd/bases/core.openfunction.io_builders.yaml
@@ -48,6 +48,9 @@ spec:
               funcType:
                 description: Function type such as HTTP or CloudEvent
                 type: string
+              funcSource:
+                description: Function source such as main.py for python
+                type: string
               funcVersion:
                 description: Function version in format like v1.0.0
                 type: string

--- a/config/crd/bases/core.openfunction.io_functions.yaml
+++ b/config/crd/bases/core.openfunction.io_functions.yaml
@@ -48,6 +48,9 @@ spec:
               funcType:
                 description: Function type such as HTTP or CloudEvent
                 type: string
+              funcSource:
+                description: FuncSource source such as main.py for python
+                type: string
               funcVersion:
                 description: Function version in format like v1.0.0
                 type: string

--- a/pkg/apis/v1alpha1/builder_types.go
+++ b/pkg/apis/v1alpha1/builder_types.go
@@ -26,6 +26,8 @@ type BuilderSpec struct {
 	FuncName string `json:"funcName"`
 	// Function type such as HTTP or CloudEvent
 	FuncType string `json:"funcType"`
+	// FuncSource source such as main.py for python
+	FuncSource string `json:"funcSource,omitempty"`
 	// Function version in format like v1.0.0
 	FuncVersion string `json:"funcVersion"`
 	// Cloud Native Buildpacks builders

--- a/pkg/apis/v1alpha1/function_types.go
+++ b/pkg/apis/v1alpha1/function_types.go
@@ -107,6 +107,8 @@ type FunctionSpec struct {
 	FuncName string `json:"funcName"`
 	// Function type such as HTTP or CloudEvent
 	FuncType string `json:"funcType"`
+	// FuncSource source such as main.py for python
+	FuncSource string `json:"funcSource,omitempty"`
 	// Function version in format like v1.0.0
 	FuncVersion string `json:"funcVersion"`
 	// Cloud Native Buildpacks builders

--- a/pkg/controllers/function_controller.go
+++ b/pkg/controllers/function_controller.go
@@ -94,6 +94,7 @@ func (r *FunctionReconciler) createOrUpdateBuilder(fn *openfunction.Function) (c
 
 	builder.Spec.FuncName = fn.Spec.FuncName
 	builder.Spec.FuncType = fn.Spec.FuncType
+	builder.Spec.FuncSource = fn.Spec.FuncSource
 	builder.Spec.FuncVersion = fn.Spec.FuncVersion
 	builder.Spec.Builder = fn.Spec.Builder
 	builder.Spec.Image = fn.Spec.Image


### PR DESCRIPTION
1. Add ```FuncSource``` parameter and set it omitempty.
2. ```FuncSource``` means the name of function file such as ```main.py``` for python.
3. **Unset it** when language function framework dose not support it.(```nodejs```, e,g.)