### PR TITLE
Change default builder to "openfunction/gcp-builder:v1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,6 @@ If you have already installed the OpenFunction platform, follow the steps below 
     spec:
       image: "<your registry name>/sample-go-func:latest"
     ```
-   > When having poor network connectivity to GitHub/Googleapis, follow these changes:
-   > 
-   > ```spec.builder``` : "openfunction/buildpacks-builder:v1"
 
     Use the following command to create this Function:
 

--- a/config/samples/function-sample.yaml
+++ b/config/samples/function-sample.yaml
@@ -7,7 +7,7 @@ spec:
   image: "openfunction/sample-go-func:latest"
   #port: 8080 # default to 8080
   build:
-    builder: "gcr.io/buildpacks/builder:v1"
+    builder: "openfunction/gcp-builder:v1"
     params:
       GOOGLE_FUNCTION_TARGET: "HelloWorld"
       GOOGLE_FUNCTION_SIGNATURE_TYPE: "http"


### PR DESCRIPTION
1. Change default builder to "openfunction/gcp-builder:v1"

Signed-off-by: laminar <fangtian@yunify.com>