### PR TITLE
Track the v0.23.0 version of Knative

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ If you have already installed the OpenFunction platform, follow the steps below 
     ```shell
     kubectl get ksvc
      
-    NAME                           URL                                                                 LATESTCREATED                        LATESTREADY                          READY   REASON
-    function-sample-serving-ksvc   http://function-sample-serving-ksvc.default.<external-ip>.nip.io   function-sample-serving-ksvc-00001   function-sample-serving-ksvc-00001   True
+    NAME                           URL                                                                  LATESTCREATED                        LATESTREADY                          READY   REASON
+    function-sample-serving-ksvc   http://function-sample-serving-ksvc.default.<external-ip>.sslip.io   function-sample-serving-ksvc-00001   function-sample-serving-ksvc-00001   True
     ```
 
     Or get the service address directly with the following command:
@@ -153,13 +153,13 @@ If you have already installed the OpenFunction platform, follow the steps below 
     ```shell
     kubectl get ksvc function-sample-serving-ksvc -o jsonpath={.status.url}
      
-    http://function-sample-serving-ksvc.default.<external-ip>.nip.io
+    http://function-sample-serving-ksvc.default.<external-ip>.sslip.io
     ```
 
     Access the above service address via commands such as ``curl``:
 
     ```shell
-    curl http://function-sample-serving-ksvc.default.<external-ip>.nip.io
+    curl http://function-sample-serving-ksvc.default.<external-ip>.sslip.io
      
     Hello, World!
     ```

--- a/docs/installation/Setup-OpenFunction-Serving-with-Knative.md
+++ b/docs/installation/Setup-OpenFunction-Serving-with-Knative.md
@@ -14,13 +14,13 @@ Choose a suitable installation of Knative CLI for your cluster by refer to this 
 #### Install the required custom resources
 
 ```bash
-kubectl apply -f https://github.com/knative/serving/releases/download/v0.22.0/serving-crds.yaml
+kubectl apply -f https://github.com/knative/serving/releases/download/v0.23.0/serving-crds.yaml
 ```
 
 #### Install the core components of Serving
 
 ```bash
-kubectl apply -f https://github.com/knative/serving/releases/download/v0.22.0/serving-core.yaml
+kubectl apply -f https://github.com/knative/serving/releases/download/v0.23.0/serving-core.yaml
 ```
 
 #### Install a networking layer
@@ -30,7 +30,7 @@ kubectl apply -f https://github.com/knative/serving/releases/download/v0.22.0/se
 1. Install the Knative Kourier controller
    
     ```bash
-    kubectl apply -f https://github.com/knative/net-kourier/releases/download/v0.22.0/kourier.yaml
+    kubectl apply -f https://github.com/knative/net-kourier/releases/download/v0.23.0/kourier.yaml
     ```
 2. To configure Knative Serving to use Kourier by default
    
@@ -79,12 +79,10 @@ webhook-75f5d4845d-lg8j5                 1/1     Running   0          11m
 
 #### Configure DNS
 
-- **Magic DNS (xip.io)**
-
-    > :grey_exclamation: Here is a known [issue](https://github.com/OpenFunction/OpenFunction/issues/33#issue-881676421) when use `xip.io` as DNS
+- **Magic DNS (sslip.io)**
 
     ```bash
-    kubectl apply -f https://github.com/knative/serving/releases/download/v0.22.0/serving-default-domain.yaml
+    kubectl apply -f https://github.com/knative/serving/releases/download/v0.23.0/serving-default-domain.yaml
     ```
 
 ### Install Knative Eventing
@@ -92,7 +90,7 @@ webhook-75f5d4845d-lg8j5                 1/1     Running   0          11m
 #### Install the core components of Eventing
 
 ```bash
-kubectl apply -f https://github.com/knative/eventing/releases/download/v0.22.0/eventing-core.yaml
+kubectl apply -f https://github.com/knative/eventing/releases/download/v0.23.0/eventing-core.yaml
 ```
 
 #### Verify the installation
@@ -116,13 +114,13 @@ Choose a suitable installation of Knative CLI for your cluster by refer to this 
 #### Install the required custom resources
 
 ```bash
-kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/serving/v0.22.0/serving-crds.yaml
+kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/serving/v0.23.0/serving-crds.yaml
 ```
 
 #### Install the core components of Serving
 
 ```bash
-kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/serving/v0.22.0/serving-core.yaml
+kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/serving/v0.23.0/serving-core.yaml
 ```
 
 #### Install a networking layer
@@ -132,7 +130,7 @@ kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/serving/v0.22.0/
 1. Install the Knative Kourier controller
 
     ```bash
-    kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/net-kourier/v0.22.0/kourier.yaml
+    kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/net-kourier/v0.23.0/kourier.yaml
     ```
 2. To configure Knative Serving to use Kourier by default
 
@@ -181,12 +179,10 @@ webhook-75f5d4845d-lg8j5                 1/1     Running   0          11m
 
 #### Configure DNS
 
-- **Magic DNS (xip.io)**
-
-    > :grey_exclamation: Here is a known [issue](https://github.com/OpenFunction/OpenFunction/issues/33#issue-881676421) when use `xip.io` as DNS
+- **Magic DNS (sslip.io)**
 
     ```bash
-    kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/serving/v0.22.0/serving-default-domain.yaml
+    kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/serving/v0.23.0/serving-default-domain.yaml
     ```
 
 ### Install Knative Eventing
@@ -194,7 +190,7 @@ webhook-75f5d4845d-lg8j5                 1/1     Running   0          11m
 #### Install the core components of Eventing
 
 ```bash
-kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/eventing/v0.22.0/eventing-core.yaml
+kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/eventing/v0.23.0/eventing-core.yaml
 ```
 
 #### Verify the installation

--- a/hack/deploy-tekon-and-knative.sh
+++ b/hack/deploy-tekon-and-knative.sh
@@ -42,26 +42,24 @@ if [ "$poor_network" = "false" ]; then
   # Install Tekton Dashboard
   kubectl apply --filename https://github.com/tektoncd/dashboard/releases/latest/download/tekton-dashboard-release.yaml
   # Install the required custom resources
-  kubectl apply -f https://github.com/knative/serving/releases/download/v0.22.0/serving-crds.yaml
+  kubectl apply -f https://github.com/knative/serving/releases/download/v0.23.0/serving-crds.yaml
   # Install the core components of Serving
-  kubectl apply -f https://github.com/knative/serving/releases/download/v0.22.0/serving-core.yaml
+  kubectl apply -f https://github.com/knative/serving/releases/download/v0.23.0/serving-core.yaml
   # Install a networking layer
   # Install the Knative Kourier controller
-  kubectl apply -f https://github.com/knative/net-kourier/releases/download/v0.22.0/kourier.yaml
+  kubectl apply -f https://github.com/knative/net-kourier/releases/download/v0.23.0/kourier.yaml
   # To configure Knative Serving to use Kourier by default
   kubectl patch configmap/config-network \
     --namespace knative-serving \
     --type merge \
     --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
   # Configure DNS
-  tempfile=`mktemp tmpd.XXXXXX.yaml`
-  wget -O- https://github.com/knative/serving/releases/download/v0.22.0/serving-default-domain.yaml | sed "s/xip.io/nip.io/g" > $tempfile
-  kubectl apply -f $tempfile && rm -f $tempfile 2 > /dev/null
+  kubectl apply -f https://github.com/knative/serving/releases/download/v0.23.0/serving-default-domain.yaml
   # Install Knative Eventing
   # Install the required custom resource definitions (CRDs)
-  #kubectl apply -f https://github.com/knative/eventing/releases/download/v0.22.0/eventing-crds.yaml
+  kubectl apply -f https://github.com/knative/eventing/releases/download/v0.23.0/eventing-crds.yaml
   # Install the core components of Eventing
-  kubectl apply -f https://github.com/knative/eventing/releases/download/v0.22.0/eventing-core.yaml
+  kubectl apply -f https://github.com/knative/eventing/releases/download/v0.23.0/eventing-core.yaml
 else
   # Install Tekton pipeline
   kubectl apply --filename https://openfunction.sh1a.qingstor.com/tekton/pipeline/v0.23.0/release.yaml
@@ -70,23 +68,23 @@ else
   # Install Tekton Dashboard
   kubectl apply --filename https://openfunction.sh1a.qingstor.com/tekton/dashboard/v0.16.0/release.yaml
   # Install the required custom resources
-  kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/serving/v0.22.0/serving-crds.yaml
+  kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/serving/v0.23.0/serving-crds.yaml
   # Install the core components of Serving
-  kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/serving/v0.22.0/serving-core.yaml
+  kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/serving/v0.23.0/serving-core.yaml
   # Install a networking layer
   # Install the Knative Kourier controller
-  kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/net-kourier/v0.22.0/kourier.yaml
+  kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/net-kourier/v0.23.0/kourier.yaml
   # To configure Knative Serving to use Kourier by default
   kubectl patch configmap/config-network \
     --namespace knative-serving \
     --type merge \
     --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
   # Configure DNS
-  kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/serving/v0.22.0/serving-default-domain.yaml
+  kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/serving/v0.23.0/serving-default-domain.yaml
   # Install the required custom resource definitions (CRDs)
-  #kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/eventing/v0.22.0/eventing-crds.yaml
+  #kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/eventing/v0.23.0/eventing-crds.yaml
   # Install the core components of Eventing
-  kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/eventing/v0.22.0/eventing-core.yaml
+  kubectl apply -f https://openfunction.sh1a.qingstor.com/knative/eventing/v0.23.0/eventing-core.yaml
 fi
 
 patch=$(echo "{\"spec\":{\"ports\":[{\"name\":\"http\",\"nodePort\":$tekton_dashboard_nodeport,\"port\":9097,\"protocol\":\"TCP\",\"targetPort\":9097}],\"type\":\"NodePort\"}}")


### PR DESCRIPTION
Track the v0.23.0 version of Knative, fix default domain by modify xip.io to sslip.io.