### PR TITLE
make the function controller owns serving an builder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/onsi/gomega v1.10.2
 	github.com/prometheus/client_golang v1.9.0 // indirect
 	github.com/tektoncd/pipeline v0.13.1-0.20200625065359-44f22a067b75
+	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	golang.org/x/net v0.0.0-20201224014010-6772e930b67b // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a // indirect


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@yunify.com>

Currently, the function controller does not watch the builder and serving, so the function controller cannot recreate them when the builder or serving is deleted. 
This pr make the function controller owns the builder and serving, thereby solving the following problems:

- Recreate the builder when the builder is deleted and the build is not completed. Rebuild can be achieved by deleting the builder when the build fails.
- Recreate the serving after serving is modified or deleted.
- If the parameters of the function are modified, the rebuild will be triggered automatically, and the serving will be re-run after the build is completed. It is easy to trigger rebuild when the function code is modified by modifying the parameter of the function, such as `image version`.
- If the runtime or parameters of serving are modified, serving will automatically re-run.

Incidentally, a parameter is added to set the log level of the operator