### PR TITLE
Optimize the cach mechanism of the function controller

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -187,7 +187,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.Level(level)))
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.Level(level), zap.StacktraceLevel(zapcore.PanicLevel)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -129,13 +129,13 @@ func onBuilderUpdate(obj interface{}) {
 
 			switch {
 			case plr.IsDone():
-				setupLog.V(1).Info("Function build completed", "Succeeded", cond.Status, "namespace", plr.Namespace, "name", fn)
+				setupLog.Info("Function build completed", "Succeeded", cond.Status, "namespace", plr.Namespace, "name", fn)
 			case plr.IsCancelled():
-				setupLog.V(1).Info("PipelineRun cancelled!")
+				setupLog.Info("PipelineRun cancelled!")
 			case plr.IsTimedOut():
-				setupLog.V(1).Info("PipelineRun timeout!")
+				setupLog.Info("PipelineRun timeout!")
 			default:
-				setupLog.V(1).Info("PipelineRun status unknown!")
+				setupLog.Info("PipelineRun status unknown!")
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mitchellh/hashstructure v1.1.0
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/prometheus/client_golang v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -860,6 +860,8 @@ github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b/go.mod h1:r1VsdOzO
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=
+github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/6d8ulp4AwfLKrmA=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/ioprogress v0.0.0-20180201004757-6a23b12fa88e/go.mod h1:waEya8ee1Ro/lgxpVhkJI4BVASzkm3UZqkx/cFJiYHM=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/pkg/controllers/builder_controller.go
+++ b/pkg/controllers/builder_controller.go
@@ -49,7 +49,7 @@ func (r *BuilderReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	if err := r.Get(ctx, req.NamespacedName, &builder); err != nil {
 		log.V(1).Info("Builder deleted", "error", err)
-		return ctrl.Result{}, util.IgnoreNotFound(client.IgnoreNotFound(err))
+		return ctrl.Result{}, util.IgnoreNotFound(err)
 	}
 
 	if _, err := r.createOrUpdateBuild(&builder); err != nil {
@@ -69,7 +69,7 @@ func (r *BuilderReconciler) createOrUpdateBuild(builder *openfunction.Builder) (
 
 	status := openfunction.BuilderStatus{Phase: openfunction.BuildPhase, State: openfunction.Launching}
 	if err := r.updateStatus(builder, &status); err != nil {
-		log.Error(err, "Failed to update builder status", "name", builder.Name, "namespace", builder.Namespace)
+		log.Error(err, "Failed to update builder Launching status", "name", builder.Name, "namespace", builder.Namespace)
 		return ctrl.Result{}, err
 	}
 
@@ -105,7 +105,7 @@ func (r *BuilderReconciler) createOrUpdateBuild(builder *openfunction.Builder) (
 
 	status = openfunction.BuilderStatus{Phase: openfunction.BuildPhase, State: openfunction.Launched}
 	if err := r.updateStatus(builder, &status); err != nil {
-		log.Error(err, "Failed to update builder status", "name", builder.Name, "namespace", builder.Namespace)
+		log.Error(err, "Failed to update builder Launched status", "name", builder.Name, "namespace", builder.Namespace)
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/controllers/builder_controller.go
+++ b/pkg/controllers/builder_controller.go
@@ -48,7 +48,7 @@ func (r *BuilderReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	var builder openfunction.Builder
 
 	if err := r.Get(ctx, req.NamespacedName, &builder); err != nil {
-		log.V(10).Info("Builder deleted", "error", err)
+		log.V(1).Info("Builder deleted", "error", err)
 		return ctrl.Result{}, util.IgnoreNotFound(client.IgnoreNotFound(err))
 	}
 
@@ -84,22 +84,22 @@ func (r *BuilderReconciler) createOrUpdateBuild(builder *openfunction.Builder) (
 	}
 
 	if err := r.CreateOrUpdateBuildpackPVCs(builder); err != nil {
-		log.Error(err, "Failed to create buildpack pvcs", "namaspace", builder.Namespace)
+		log.Error(err, "Failed to create buildpack pvcs", "namespace", builder.Namespace)
 		return ctrl.Result{}, err
 	}
 
 	if err := r.CreateOrUpdateRegistryAuth(builder); err != nil {
-		log.Error(err, "Failed to create registry auth", "namaspace", builder.Namespace)
+		log.Error(err, "Failed to create registry auth", "namespace", builder.Namespace)
 		return ctrl.Result{}, err
 	}
 
 	if err := r.CreateOrUpdatePipeline(builder); err != nil {
-		log.Error(err, "Failed to create Pipeline", "namaspace", builder.Namespace)
+		log.Error(err, "Failed to create Pipeline", "namespace", builder.Namespace)
 		return ctrl.Result{}, err
 	}
 
 	if err := r.CreateOrUpdatePipelineRun(builder); err != nil {
-		log.Error(err, "Failed to create PipelineRun", "namaspace", builder.Namespace)
+		log.Error(err, "Failed to create PipelineRun", "namespace", builder.Namespace)
 		return ctrl.Result{}, err
 	}
 
@@ -114,13 +114,8 @@ func (r *BuilderReconciler) createOrUpdateBuild(builder *openfunction.Builder) (
 
 func (r *BuilderReconciler) updateStatus(builder *openfunction.Builder, status *openfunction.BuilderStatus) error {
 
-	b := openfunction.Builder{}
-	if err := r.Get(r.ctx, client.ObjectKey{Namespace: builder.Namespace, Name: builder.Name}, &b); err != nil {
-		return err
-	}
-
-	status.DeepCopyInto(&b.Status)
-	if err := r.Status().Update(r.ctx, &b); err != nil {
+	status.DeepCopyInto(&builder.Status)
+	if err := r.Status().Update(r.ctx, builder); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/controllers/serving_controller.go
+++ b/pkg/controllers/serving_controller.go
@@ -19,11 +19,11 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"github.com/openfunction/pkg/util"
 	"strings"
 
 	"github.com/go-logr/logr"
 	openfunction "github.com/openfunction/pkg/apis/v1alpha1"
+	"github.com/openfunction/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,7 +54,7 @@ func (r *ServingReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	if err := r.Get(ctx, req.NamespacedName, &s); err != nil {
 		log.V(1).Info("Serving deleted", "error", err)
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		return ctrl.Result{}, util.IgnoreNotFound(err)
 	}
 
 	if _, err := r.createOrUpdateServing(&s); err != nil {
@@ -136,27 +136,34 @@ func (r *ServingReconciler) createOrUpdateServing(s *openfunction.Serving) (ctrl
 	ksvc.Name = fmt.Sprintf("%s-%s", s.Name, "ksvc")
 	ksvc.Namespace = s.Namespace
 
-	if err := r.Delete(r.ctx, &ksvc); util.IgnoreNotFound(client.IgnoreNotFound(err)) != nil {
+	status := openfunction.ServingStatus{Phase: openfunction.ServingPhase, State: openfunction.Launching}
+	if err := r.updateStatus(s, &status); err != nil {
+		log.Error(err, "Failed to update serving Launching status", "name", s.Name, "namespace", s.Namespace)
+		return ctrl.Result{}, err
+	}
+
+	if err := r.Delete(r.ctx, &ksvc); util.IgnoreNotFound(err) != nil {
 		log.Error(err, "Failed to delete old knative service", "name", ksvc.Name, "namespace", ksvc.Namespace)
 		return ctrl.Result{}, err
 	}
 
-	status := openfunction.ServingStatus{Phase: openfunction.ServingPhase, State: openfunction.Launching}
-	if err := r.updateStatus(s, &status); err != nil {
-		log.Error(err, "Failed to update serving status", "name", s.Name, "namespace", s.Namespace)
+	if err := r.mutateKsvc(&ksvc, s)(); err != nil {
+		log.Error(err, "Failed to mutate knative service", "name", s.Name, "namespace", s.Namespace)
 		return ctrl.Result{}, err
 	}
 
-	if result, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, &ksvc, r.mutateKsvc(&ksvc, s)); err != nil {
-		log.Error(err, "Failed to CreateOrUpdate knative service", "result", result)
+	if err := r.Create(r.ctx, &ksvc); err != nil {
+		log.Error(err, "Failed to Create knative service", "name", s.Name, "namespace", s.Namespace)
 		return ctrl.Result{}, err
 	}
 
 	status = openfunction.ServingStatus{Phase: openfunction.ServingPhase, State: openfunction.Launched}
 	if err := r.updateStatus(s, &status); err != nil {
-		log.Error(err, "Failed to update serving status", "name", s.Name, "namespace", s.Namespace)
+		log.Error(err, "Failed to update serving Launched status", "name", s.Name, "namespace", s.Namespace)
 		return ctrl.Result{}, err
 	}
+
+	log.V(1).Info("Create serving", "name", s.Name, "namespace", s.Namespace)
 
 	return ctrl.Result{}, nil
 }

--- a/pkg/controllers/serving_controller.go
+++ b/pkg/controllers/serving_controller.go
@@ -53,7 +53,7 @@ func (r *ServingReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	var s openfunction.Serving
 
 	if err := r.Get(ctx, req.NamespacedName, &s); err != nil {
-		log.V(10).Info("Serving deleted", "error", err)
+		log.V(1).Info("Serving deleted", "error", err)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -162,13 +162,9 @@ func (r *ServingReconciler) createOrUpdateServing(s *openfunction.Serving) (ctrl
 }
 
 func (r *ServingReconciler) updateStatus(s *openfunction.Serving, status *openfunction.ServingStatus) error {
-	serving := openfunction.Serving{}
-	if err := r.Get(r.ctx, client.ObjectKey{Namespace: s.Namespace, Name: s.Name}, &serving); err != nil {
-		return err
-	}
 
-	status.DeepCopyInto(&serving.Status)
-	if err := r.Status().Update(r.ctx, &serving); err != nil {
+	status.DeepCopyInto(&s.Status)
+	if err := r.Status().Update(r.ctx, s); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -12,8 +12,23 @@ const (
 // IgnoreNotFound returns nil on 'not found' errors.
 // All other values that are not 'not found' errors or nil are returned unmodified.
 func IgnoreNotFound(err error) error {
-	if errors.ReasonForError(err) == CRNotFound {
+
+	if err == nil {
 		return nil
 	}
+
+	if errors.ReasonForError(err) == CRNotFound || errors.ReasonForError(err) == metav1.StatusReasonNotFound {
+		return nil
+	}
+
 	return err
+}
+
+func IsNotFound(err error) bool {
+
+	if err == nil {
+		return false
+	}
+
+	return errors.IsNotFound(err)
 }

--- a/pkg/util/hash.go
+++ b/pkg/util/hash.go
@@ -1,0 +1,13 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/hashstructure"
+)
+
+func Hash(val interface{}) string {
+
+	hash, _ := hashstructure.Hash(val, nil)
+	return fmt.Sprintf("%d", hash)
+}


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@yunify.com>

Replace cache builder and serving with cache function, the cache will be updated after function reconciles successful, and deleted after the function is deleted.
The following figure shows the complete cache mechanism and the logic of determining whether the builder and serving need to be updated through the cache.

<img width="648" alt="cache" src="https://user-images.githubusercontent.com/53003665/121001106-850e8600-c7bd-11eb-950d-7cb001bfd8d2.png">




