### PR TITLE
Update events framework docs and eventbus name template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-```OpenFunction``` is a cloud-native open source FaaS (Function as a Service) platform aiming to enable users to focus on their business logic without worrying about the underlying runtime environment and infrastructure. Users only need to submit business-related source code in the form of functions.
+**OpenFunction** is a cloud-native open source FaaS (Function as a Service) platform aiming to enable users to focus on their business logic without worrying about the underlying runtime environment and infrastructure. Users only need to submit business-related source code in the form of functions.
 
-```OpenFunction``` features but not limited to the following:
+OpenFunction features but not limited to the following:
 
 - Convert business-related function source code to runnable application source code.
 - Generate a deployable container image from the converted application source code.
@@ -16,19 +16,21 @@
 
 ## CustomResourceDefinitions
 
-The core function of OpenFunction is to enable users to develop, run, and manage business applications as execution units of code functions. OpenFunction implements the following [custom resource definitions (CRDs)](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/):  
+### Core CRDs
+
+The core capability of OpenFunction is to enable users to develop, run and manage applications as executable function code. OpenFunction implements the following [custom resource definitions (CRDs)](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/):  
 
 - **Function**, defines a function.
 - **Builder**, defines a function builder.
 - **Serving**, defines a function workload.
 
-### Function
+#### Function
 
 The goal of Function is to control the lifecycle management from user code to the final application that can respond to events through a single profile.
 
 Function will manage and coordinate Builder and Serving resources to handle the details of the process.
 
-### Builder
+#### Builder
 
 The goal of Builder is to compile the user's function source code into an application image that can be run in a cloud-native environment.
 
@@ -36,7 +38,7 @@ It will fetch the code from the code repository, build the application image loc
 
 Currently, OpenFunction Builder uses [Tekton and Cloud Native Buildpacks](#tekton-and-cloud-native-buildpacks) to build container images.
 
-#### Tekton and Cloud Native Buildpacks
+##### Tekton and Cloud Native Buildpacks
 
 Tekton is a CI/CD system that provides task pipelining capabilities. 
 
@@ -44,23 +46,29 @@ Cloud Native Buildpacks is an OCI standard image building framework that transfo
 
 OpenFunction Builder controls the build process of application images by Tekton, including fetching code, building and publishing images via Cloud Native Buildpacks.
 
-### Serving
+#### Serving
 
 The goal of Serving is to serving user functions and implementing event-driven functions response.
 
 Currently, OpenFunction supports two serving runtimes, [Knative](#knative) and [OpenFuncAsync](#openfuncasync). At least one of these runtimes needs to be installed.
 
-#### Knative
+##### Knative
 
 Knative Serving builds on Kubernetes to support deploying and serving serverless applications and functions. Knative Serving is easy to get started with and scales to support advanced scenarios.
 
-#### OpenFuncAsync
+##### OpenFuncAsync
 
 OpenFuncAsync is an event-driven Serving runtime. It is implemented based on KEDA + Dapr.
 
 You can refer to [Prerequisites](#prerequisites) and use `--with-openFuncAsync` to install OpenFuncAsync runtime.
 
 The OpenFuncAsync runtime can be triggered by a variety of event types, such as MQ, cronjob, DB events, etc. In Kubernetes cluster, OpenFuncAsync will be triggered in the form of deployments or jobs.
+
+### Events CRDs
+
+OpenFunction also provides an event handling framework that complements the event-driven capabilities of OpenFunction as a FaaS framework.
+
+You can refer to [OpenFunction Events Framework Concepts](docs/concepts/OpenFunction-events-framework.md) for more information.
 
 ## QuickStart
 

--- a/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ package v1alpha1
 
 import (
 	apiv1alpha1 "github.com/kedacore/keda/v2/api/v1alpha1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/controllers/events/event.go
+++ b/controllers/events/event.go
@@ -28,10 +28,10 @@ const (
 	EventSourceComponentNameTmpl = "eventsource-%s-%s-%s"
 	// EventSourceSinkComponentNameTmpl => eventsource-sink-{eventSourceName}
 	EventSourceSinkComponentNameTmpl = "eventsource-sink-%s"
-	// EventSourceBusComponentNameTmpl => eventsource-eventbus-{eventSourceName}
-	EventSourceBusComponentNameTmpl = "eventsource-eventbus-%s"
-	// TriggerBusComponentNameTmpl => trigger-eventbus-{triggerName}
-	TriggerBusComponentNameTmpl = "trigger-eventbus-%s"
+	// EventSourceBusComponentNameTmpl => eventbus-eventsource-{eventSourceName}
+	EventSourceBusComponentNameTmpl = "eventbus-eventsource-%s"
+	// TriggerBusComponentNameTmpl => eventbus-trigger-{triggerName}
+	TriggerBusComponentNameTmpl = "eventbus-trigger-%s"
 	// TriggerSinkComponentNameTmpl => trigger-sink-{triggerName}-{sinkNamespace}-{sinkName}
 	TriggerSinkComponentNameTmpl = "trigger-sink-%s-%s-%s"
 	// EventSourceWorkloadsNameTmpl => eventsource-{eventSourceName}-{sourceKind}-{eventName}

--- a/docs/concepts/OpenFunction-events-framework.md
+++ b/docs/concepts/OpenFunction-events-framework.md
@@ -1,3 +1,16 @@
+- [Overview](#overview)
+  * [Features](#features)
+- [Concepts](#concepts)
+  * [Architecture](#architecture)
+  * [EventSource](#eventsource)
+  * [EventBus(ClusterEventBus)](#eventbusclustereventbus)
+  * [Trigger](#trigger)
+- [Getting Started](#getting-started)
+  * [Sample 1: Event source trigger synchronization function](#sample-1-event-source-trigger-synchronization-function)
+  * [Sample 2: Use of event bus and triggers](#sample-2-use-of-event-bus-and-triggers)
+  * [Sample 3: Multi sources in one EventSource](#sample-3-multi-sources-in-one-eventsource)
+  * [Sample 4: EventBus and ClusterEventBus](#sample-4-eventbus-and-clustereventbus)
+
 # Overview
 
 **OpenFunction Events** is the event management framework for OpenFunction.
@@ -20,7 +33,7 @@ Represents the producer of an event, such as a Kafka service, an object storage 
 
 The **EventSource** contains a description of these event producers  and is also responsible for directing where the events they generate should go.
 
-### Available:
+### Available
 
 - Kafka
 - Cron (scheduler)
@@ -34,7 +47,7 @@ The **EventBus** contains a description of the event bus backend service (usuall
 
 EventBus will take care of event bus adaptation for namespaced scope by default, while we provide an event bus adapter **ClusterEventBus** for clustered scope. **ClusterEventBus** will take effect when other components do not find an EventBus under the namespace.
 
-### Available:
+### Available
 
 - NATS Streaming
 
@@ -276,8 +289,8 @@ You will observe the following changes:
 > 1. Create EventSource CR called "my-eventsource"
 > 2. Retrieve and reorganize the configuration of the EventBus (used to pass in the Deployments in step 5), including:
      >    1. The EventBus name ("default" in this sample)
->    2. The name of the Dapr Component associated with the EventBus ("eventsource-eventbus-my-eventsource" in this sample)
-> 3. Create a Dapr Component called "eventsource-eventbus-my-eventsource" for associating the event bus
+>    2. The name of the Dapr Component associated with the EventBus ("eventbus-eventsource-my-eventsource" in this sample)
+> 3. Create a Dapr Component called "eventbus-eventsource-my-eventsource" for associating the event bus
 > 4. Create a Dapr Component called "eventsource-my-eventsource-kafka-sample-two" for associating the event source
 > 5. Create a Deployments called "eventsource-my-eventsource-kafka-sample-two" for processing events
 
@@ -292,7 +305,7 @@ default   10m
 
 ~# kubectl get components
 NAME                                          AGE
-eventsource-eventbus-my-eventsource           28s
+eventbus-eventsource-my-eventsource           28s
 eventsource-my-eventsource-kafka-sample-two   28s
 
 ~# kubectl get deployments.apps
@@ -347,8 +360,8 @@ You will observe the following changes :
 > 1. Create a Trigger CR called "my-trigger"
 > 2. Retrieve and reorganize the configuration of the EventBus (used to pass in the Deployments in step 5), including:
      >    1. The EventBus name ("default" in this sample)
->    2. The name of the Dapr Component associated with the EventBus ("trigger-eventbus-my-trigger" in this sample)
-> 3. Create a Dapr Component called "trigger-eventbus-my-trigger" for associating the event bus
+>    2. The name of the Dapr Component associated with the EventBus ("eventbus-trigger-my-trigger" in this sample)
+> 3. Create a Dapr Component called "eventbus-trigger-my-trigger" for associating the event bus
 > 4. Create a Dapr Component called "trigger-sink-my-trigger-default-function-sample-serving-ksvc" for associating the target function
 > 5. Create a Deployments called "trigger-my-trigger" to handle trigger tasks
 
@@ -363,7 +376,7 @@ default   62m
 
 ~# kubectl get components
 NAME                                                           AGE
-trigger-eventbus-my-trigger                                    34m
+eventbus-trigger-my-trigger                                    34m
 trigger-sink-my-trigger-default-function-sample-serving-ksvc   34m
 
 ~# kubectl get deployments.apps
@@ -437,7 +450,7 @@ function-sample-serving-ksvc-v100-deployment-5df4f559db-h69xj   2/2     Running 
 
 ## Sample 3: Multi sources in one EventSource
 
-We add an event source configuration to the EventSource based on [Sample 1](#Sample 1:Event source trigger synchronization function) .
+We add an event source configuration to the EventSource based on [Sample 1](#sample-1-event-source-trigger-synchronization-function) .
 
 Create an EventSource configuration `eventsource-multi.yaml` :
 
@@ -510,7 +523,7 @@ The role of the `cron` event is to trigger the function in sink every 5 seconds.
 
 ## Sample 4: EventBus and ClusterEventBus
 
-Based on [Sample 2](#Sample 2: Use of event bus and triggers), we try to use a ClusterEventBus instead of an EventBus in the namespace.
+Based on [Sample 2](#sample-2-use-of-event-bus-and-triggers), we try to use a ClusterEventBus instead of an EventBus in the namespace.
 
 Create a ClusterEventBus configuration `clustereventbus-default.yaml` ：
 


### PR DESCRIPTION
1. Adjusted the Readme and added a section for Events CRDs and a link to jump to Events related documentation
2. Adjusted the name template of the eventbus component generated by EventSource and Trigger

Signed-off-by: laminar <fangtian@kubesphere.io>