### PR TITLE
fix: Dockerfile && rbac configurations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN GOPROXY="https://goproxy.cn" go mod download
 
 # Copy the go source
 COPY main.go main.go
-COPY api/ api/
+COPY apis/ apis/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
@@ -23,6 +23,6 @@ RUN GOPROXY="https://goproxy.cn" CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODU
 FROM openfunction/distroless-static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/openfunction .
-USER nonroot:nonroot
+USER 65532:65532
 
 ENTRYPOINT ["/openfunction"]

--- a/config/bundle.yaml
+++ b/config/bundle.yaml
@@ -14391,6 +14391,58 @@ rules:
 - apiGroups:
   - events.openfunction.io
   resources:
+  - clustereventbus
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - events.openfunction.io
+  resources:
+  - clustereventbus/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - events.openfunction.io
+  resources:
+  - clustereventbus/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - events.openfunction.io
+  resources:
+  - eventbus
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - events.openfunction.io
+  resources:
+  - eventbus/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - events.openfunction.io
+  resources:
+  - eventbus/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - events.openfunction.io
+  resources:
   - eventsources
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -129,6 +129,58 @@ rules:
 - apiGroups:
   - events.openfunction.io
   resources:
+  - clustereventbus
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - events.openfunction.io
+  resources:
+  - clustereventbus/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - events.openfunction.io
+  resources:
+  - clustereventbus/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - events.openfunction.io
+  resources:
+  - eventbus
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - events.openfunction.io
+  resources:
+  - eventbus/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - events.openfunction.io
+  resources:
+  - eventbus/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - events.openfunction.io
+  resources:
   - eventsources
   verbs:
   - create

--- a/controllers/events/eventsource_controller.go
+++ b/controllers/events/eventsource_controller.go
@@ -62,6 +62,12 @@ type EventSourceReconciler struct {
 //+kubebuilder:rbac:groups=events.openfunction.io,resources=eventsources,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=events.openfunction.io,resources=eventsources/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=events.openfunction.io,resources=eventsources/finalizers,verbs=update
+//+kubebuilder:rbac:groups=events.openfunction.io,resources=eventbus,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=events.openfunction.io,resources=eventbus/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=events.openfunction.io,resources=eventbus/finalizers,verbs=update
+//+kubebuilder:rbac:groups=events.openfunction.io,resources=clustereventbus,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=events.openfunction.io,resources=clustereventbus/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=events.openfunction.io,resources=clustereventbus/finalizers,verbs=update
 //+kubebuilder:rbac:groups=dapr.io,resources=components;subscriptions,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/controllers/events/trigger_controller.go
+++ b/controllers/events/trigger_controller.go
@@ -72,6 +72,13 @@ type Subscribers struct {
 //+kubebuilder:rbac:groups=events.openfunction.io,resources=triggers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=events.openfunction.io,resources=triggers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=events.openfunction.io,resources=triggers/finalizers,verbs=update
+//+kubebuilder:rbac:groups=events.openfunction.io,resources=eventbus,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=events.openfunction.io,resources=eventbus/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=events.openfunction.io,resources=eventbus/finalizers,verbs=update
+//+kubebuilder:rbac:groups=events.openfunction.io,resources=clustereventbus,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=events.openfunction.io,resources=clustereventbus/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=events.openfunction.io,resources=clustereventbus/finalizers,verbs=update
+//+kubebuilder:rbac:groups=dapr.io,resources=components;subscriptions,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
**Dockerfile**
If we use the `nonroot` user in the image and set `runAsNonRoot` in the container, then the following exception will occur:
```
Error: container has runAsNonRoot and image has non-numeric user (nonroot), cannot verify user is non-root
```

**RBAC**
Added RBAC rules for watching EventBus and ClusterEventBus in the ApiGroup "events.openfunction.io"

Signed-off-by: laminar <fangtian@kubesphere.io>