### PR TITLE
fix: eventsource bug with an error sinkoutput name

### DIFF
--- a/controllers/events/eventsource_controller.go
+++ b/controllers/events/eventsource_controller.go
@@ -250,11 +250,12 @@ func (r *EventSourceReconciler) handleSink(ctx context.Context, log logr.Logger,
 		return err
 	}
 
+	sinkOutputName := fmt.Sprintf(SinkOutputNameTmpl, sink.Ref.Namespace, sink.Ref.Name)
 	// Set EventSourceConfig.SinkOutputName.
-	r.EventSourceConfig.SinkOutputName = fmt.Sprintf(SinkOutputNameTmpl, sink.Ref.Namespace, sink.Ref.Name)
+	r.EventSourceConfig.SinkOutputName = sinkOutputName
 
 	// Add the component spec to function.
-	if function := addSinkForFunction(eventSource.Name, r.Function, component); function != nil {
+	if function := addSinkForFunction(sinkOutputName, r.Function, component); function != nil {
 		r.Function = function
 	}
 	return nil


### PR DESCRIPTION
An incorrect **sinkOutputName** was used in the EventSource direct sink trigger function, fixed

Scope: use EventSource to trigger sink directly 

Signed-off-by: laminar <fangtian@kubesphere.io>