### PR TITLE
fix bug rerun serving failed.

### DIFF
--- a/controllers/core/serving_controller.go
+++ b/controllers/core/serving_controller.go
@@ -60,7 +60,7 @@ type ServingReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *ServingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.ctx = ctx
-	log := r.Log.WithValues("serving", req.NamespacedName)
+	log := r.Log.WithValues("Serving", req.NamespacedName)
 
 	var s openfunction.Serving
 
@@ -83,18 +83,18 @@ func (r *ServingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if err := servingRun.Run(&s); err != nil {
-		log.Error(err, "Failed to run serving", "name", s.Name, "namespace", s.Namespace)
+		log.Error(err, "Failed to run serving")
 		return ctrl.Result{}, err
 	}
 
 	s.Status.Phase = openfunction.ServingPhase
 	s.Status.State = openfunction.Running
 	if err := r.Status().Update(r.ctx, &s); err != nil {
-		log.Error(err, "Failed to update serving status", "name", s.Name, "namespace", s.Namespace)
+		log.Error(err, "Failed to update serving status")
 		return ctrl.Result{}, err
 	}
 
-	log.V(1).Info("Serving is running", "name", s.Name, "namespace", s.Namespace)
+	log.V(1).Info("Serving is running")
 
 	return ctrl.Result{}, nil
 }

--- a/hack/delete.sh
+++ b/hack/delete.sh
@@ -85,6 +85,7 @@ if [ "$with_openFuncAsync" = "true" ]; then
     wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s 1.4.0
     # Init dapr
     dapr uninstall -k --all
+    kubectl delete ns dapr-system
     # Installs the latest release version
     kubectl delete -f https://github.com/kedacore/keda/releases/download/v2.4.0/keda-2.4.0.yaml
    else

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	FunctionLabel = "openfunction.io/function"
+)


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@yunify.com>

The dapr component defined in the function now has a static name, and the serving needs to be the owner of the dapr.
When the Function changes, a new serving will be created, the old serving will be deleted after the new serving is running.
The operation of setting the new service as the "Controller OwnerReference" on the dapr component will fail because the old serving is the owner of the dapr component. So the new serving will not run, and the old serving will not be deleted.

The solution is to set a changed name for dapr component like `<serving name>-component-<random string>`.
