### PR TITLE
Feat: add main CI test

### DIFF
--- a/.github/workflows/kind/kind.yaml
+++ b/.github/workflows/kind/kind.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.21.2
+  extraMounts:
+  - hostPath: /etc/localtime
+    containerPath: /etc/localtime
+  # extraPortMappings:
+  # - containerPort: 8080
+  #   hostPort: 8080

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,345 @@
+name: Main CI WorkFlow
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release-*'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'main'
+      - 'release-*'
+env:
+  OF_IMAGE: openfunction:latest
+  REGISTRY_SERVER: https://index.docker.io/v1/
+  REGISTRY_USER: ${{ secrets.DOCKERHUB_USERNAME }}
+  REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Basic test and verify
+    env:
+      GO111MODULE: "on"
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install kubebuilder-3.1.0
+        run: |
+          curl -L -o kubebuilder "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v3.1.0/kubebuilder_linux_amd64"
+          chmod +x kubebuilder && mv kubebuilder /usr/local/bin/
+      - name: Run basic test
+        run: make test
+
+      - name: Run verify crds test
+        run:  make verify
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Binary build
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - run: make binary
+        name: Run build all binaries
+       
+  docker_build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Docker image build
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: build image
+        run: |
+          docker build . -t ${{ env.REGISTRY_USER }}/${{ env.OF_IMAGE }} -f Dockerfile --build-arg GOPROXY="https://proxy.golang.org"
+  
+  openfunction_build_check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Test the build process
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY_SERVER }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}  
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        with:
+          config: .github/workflows/kind/kind.yaml
+
+      - name: Install related dependencies
+        run: |
+          chmod a+x ./hack/deploy.sh && ./hack/deploy.sh --with-shipwright
+
+      - name: Waiting for 60 seconds to keep the dependencies installed
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '60s'
+
+      - name: Install openfunction CRDs and controllers
+        run: |
+          kubectl create -f config/bundle.yaml
+
+      - name: Waiting for 60 seconds to keep the CRD and controllers installed
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '60s'
+
+      - name: Create push-secret
+        run: |
+          kubectl create secret docker-registry push-secret \
+              --docker-server=${{ env.REGISTRY_SERVER }} \
+              --docker-username=${{ env.REGISTRY_USER }} \
+              --docker-password=${{ env.REGISTRY_PASSWORD }} 
+
+      - name: Deploy function build sample
+        run: |
+          cat config/samples/function-sample-build-only.yaml | sed -e 's/openfunctiondev/${{ env.REGISTRY_USER }}/g' | kubectl apply -f -
+
+      - name: Waiting for 3 min to keep the build process
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '180s'       
+
+      - name: Verify build
+        run: |
+          docker pull ${{ env.REGISTRY_USER }}/sample-go-func:latest
+
+      - name: Uninstall openfunction CRDs and controllers
+        run: |
+          kubectl delete -f config/bundle.yaml 
+
+  openfunction_sync_func_check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Install and uninstall sync function 
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        with:
+          config: .github/workflows/kind/kind.yaml
+
+      - name: Install related dependencies
+        run: |
+          chmod a+x ./hack/deploy.sh && ./hack/deploy.sh --with-knative
+          kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.6.0/release.yaml
+          kubectl -n shipwright-build scale deployments.apps shipwright-build-controller --replicas=0
+
+      - name: Waiting for 90 seconds to keep the dependencies installed
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '90s'
+
+      - name: Install openfunction CRDs and controllers
+        run: |
+          kubectl create -f config/bundle.yaml
+
+      - name: Waiting for 60 seconds to keep the CRD and controllers installed
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '60s'
+
+      - name: Deploy sync function serving sample
+        run: |
+          cat config/samples/function-sample-serving-only.yaml | kubectl apply -f -
+
+      - name: Set environmental variables
+        run: |
+          NODE_IP=$(kubectl get nodes -o jsonpath={.items[0].status.addresses[0].address})
+          echo "NODE_IP=$NODE_IP" >> $GITHUB_ENV
+
+      - name: Patch svc kourier
+        run: | 
+            echo "Patch svc kourier with node ip: $NODE_IP"
+            kubectl patch svc -n kourier-system kourier -p "{\"spec\": {\"type\": \"LoadBalancer\", \"externalIPs\": [\"${NODE_IP}\"]}}"
+            kubectl patch configmap/config-domain -n knative-serving  --type merge --patch "{\"data\":{\"${NODE_IP}.sslip.io\":\"\"}}"
+
+      - name: Waiting for 10 seconds to make sure the function is woken up
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '10s'
+
+      - name: Check the related resources
+        run: |
+            echo "Get functions.core.openfunction.io:"
+            echo "------"
+            kubectl get functions.core.openfunction.io
+            echo "------"
+
+            echo "Get serving status:"
+            echo "------"
+            kubectl get servings.core.openfunction.io
+            echo "------"
+
+            echo "Get revision messages:"
+            echo "------"
+            kubectl describe revision -A
+            echo "------"
+
+            echo "Get Knative serving logs:"
+            echo "------"
+            kubectl -n knative-serving -l app.kubernetes.io/name=controller logs   
+            echo "------"
+
+            echo "Get all pods status:"  
+            kubectl get pods -A
+            echo "------"                
+
+      - name: Verify serving
+        run: |
+          status=`kubectl get ksvc -o jsonpath={.items}`
+          if [ "$status" = "[]" ]; then
+            echo "Cannot find function serving, exit..."
+            exit 1
+          fi
+          server_url=`kubectl get ksvc -o jsonpath={.items[0].status.url}`
+          echo "Function now is serving on ${server_url}"
+          curl ${server_url}
+          res=$?
+          if test "$res" != "0"; then
+             echo "the curl command failed with: $res"
+          fi
+
+      - name: Uninstall openfunction CRDs and controllers
+        run: |
+          kubectl delete -f config/bundle.yaml
+
+  openfunction_async_func_check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Install and uninstall async function 
+    steps:
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        with:
+          config: .github/workflows/kind/kind.yaml
+
+      - name: Install related dependencies
+        run: |
+          chmod a+x ./hack/deploy.sh && ./hack/deploy.sh --with-openFuncAsync --with-shipwright 
+
+      - name: Waiting for 90 seconds to keep the dependencies installed
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '90s'
+
+      - name: Setting up strimzi kafka operator
+        run: |
+          helm repo add strimzi https://strimzi.io/charts/
+          helm install kafka-operator -n default strimzi/strimzi-kafka-operator
+
+      - name: Waiting for 60 seconds to keep the kafka operator installed
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '60s'
+      
+      - name: Install kafka instances
+        run: |
+          cat config/samples/function-kafka-quick.yaml | kubectl apply -f -
+
+      - name: Waiting for 30 seconds to keep the kafka cluster installed
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '30s'
+
+      - name: Install openfunction CRDs and controllers
+        run: |
+          kubectl create -f config/bundle.yaml
+
+      - name: Waiting for 60 seconds to keep the CRD and controllers installed
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '60s'
+
+      - name: Deploy async function pubsub serving sample
+        run: |
+          cat config/samples/function-pubsub-sample-serving-only.yaml | kubectl apply -f -
+      
+      - name: Waiting for 25 seconds to keep the producers installed
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '25s'
+
+      - name: Checking nums of the pods before waiting
+        run: |
+          kubectl get pods 
+
+      - name: Waiting for 30 seconds to see the consumers
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '30s'
+      
+      - name: Checking nums of the pods after waiting
+        run: |
+          kubectl get pods 
+
+      - name: Uninstall openfunction CRDs and controllers
+        run: |
+          kubectl delete -f config/bundle.yaml 

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ testbin/*
 *.swp
 *.swo
 *~
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
+ARG GOPROXY="https://goproxy.cn"
+
 # Build the openfunction binary
 FROM golang:1.16 as builder
+ARG GOPROXY
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -7,7 +10,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN GOPROXY="https://goproxy.cn" go mod download
+RUN GOPROXY=$GOPROXY go mod download
 
 # Copy the go source
 COPY main.go main.go
@@ -16,7 +19,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN GOPROXY="https://goproxy.cn" CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o openfunction main.go
+RUN GOPROXY=$GOPROXY CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o openfunction main.go
 
 # Use distroless as minimal base image to package the openfunction binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/config/samples/function-kafka-quick.yaml
+++ b/config/samples/function-kafka-quick.yaml
@@ -1,0 +1,47 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: kafka-pubsub-server
+  namespace: default
+spec:
+  kafka:
+    version: 2.8.0
+    replicas: 1
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      log.message.format.version: '2.8'
+      inter.broker.protocol.version: "2.8"
+    storage:
+      type: ephemeral
+  zookeeper:
+    replicas: 1
+    storage:
+      type: ephemeral
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+---
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: logs
+  namespace: default
+  labels:
+    strimzi.io/cluster: kafka-pubsub-server
+spec:
+  partitions: 10
+  replicas: 3
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824

--- a/config/samples/function-pubsub-sample-serving-only.yaml
+++ b/config/samples/function-pubsub-sample-serving-only.yaml
@@ -1,0 +1,88 @@
+apiVersion: core.openfunction.io/v1alpha2
+kind: Function
+metadata:
+  name: autoscaling-producer
+spec:
+  version: "v1.0.0"
+  image: openfunctiondev/autoscaling-producer:latest
+  serving:
+    template:
+      containers:
+        - name: function
+          imagePullPolicy: Always
+    runtime: "OpenFuncAsync"
+    params:
+      OUTPUT_NAME: producer
+      TOPIC_NAME: metric
+      NUMBER_OF_PUBLISHERS: "2"
+      PUBLISHERS_FREQ: "100ms"
+      PUBLISHERS_DELAY: "10s"
+      LOG_FREQ: "3s"
+      PUBLISH_TO_CONSOLE: "false"
+    openFuncAsync:
+      dapr:
+        outputs:
+          - name: producer
+            component: autoscaling-producer
+            type: pubsub
+            topic: metric
+        annotations:
+          "dapr.io/log-level": "debug"
+        components:
+          autoscaling-producer:
+            type: pubsub.kafka
+            version: v1
+            metadata:
+              - name: brokers
+                value: "kafka-pubsub-server-kafka-brokers:9092"
+              - name: authRequired
+                value: "false"
+              - name: allowedTopics
+                value: "metric"
+              - name: consumerID
+                value: "autoscaling-producer"
+---
+apiVersion: core.openfunction.io/v1alpha2
+kind: Function
+metadata:
+  name: autoscaling-subscriber
+spec:
+  version: "v1.0.0"
+  image: openfunctiondev/autoscaling-subscriber:latest
+  serving:
+    runtime: "OpenFuncAsync"
+    openFuncAsync:
+      dapr:
+        inputs:
+          - name: subscriber
+            component: autoscaling-subscriber
+            type: pubsub
+            topic: metric
+        annotations:
+          dapr.io/log-level: "debug"
+        components:
+          autoscaling-subscriber:
+            type: pubsub.kafka
+            version: v1
+            metadata:
+              - name: brokers
+                value: "kafka-pubsub-server-kafka-brokers:9092"
+              - name: authRequired
+                value: "false"
+              - name: allowedTopics
+                value: "metric"
+              - name: consumerID
+                value: "autoscaling-subscriber"
+      keda:
+        scaledObject:
+          pollingInterval: 15
+          minReplicaCount: 0
+          maxReplicaCount: 10
+          cooldownPeriod: 30
+          triggers:
+            - type: kafka
+              metadata:
+                topic: metric
+                bootstrapServers: kafka-pubsub-server-kafka-brokers.default.svc.cluster.local:9092
+                consumerGroup: autoscaling-subscriber
+                lagThreshold: "10"

--- a/config/samples/function-sample-build-only.yaml
+++ b/config/samples/function-sample-build-only.yaml
@@ -1,0 +1,19 @@
+apiVersion: core.openfunction.io/v1alpha2
+kind: Function
+metadata:
+  name: function-sample
+spec:
+  version: "v1.0.0"
+  image: "openfunctiondev/sample-go-func:latest"
+  imageCredentials:
+    name: push-secret
+  #port: 8080 # default to 8080
+  build:
+    builder: openfunction/builder:v1
+    env:
+      FUNC_NAME: "HelloWorld"
+      FUNC_TYPE: "http"
+      #FUNC_SRC: "main.py"
+    srcRepo:
+      url: "https://github.com/OpenFunction/samples.git"
+      sourceSubPath: "latest/functions/Knative/hello-world-go"

--- a/config/samples/function-sample-serving-only.yaml
+++ b/config/samples/function-sample-serving-only.yaml
@@ -1,0 +1,15 @@
+apiVersion: core.openfunction.io/v1alpha2
+kind: Function
+metadata:
+  name: function-sample
+spec:
+  version: "v1.0.0"
+  image: "openfunctiondev/sample-go-func:latest"
+  #port: 8080 # default to 8080
+  serving:
+    runtime: Knative
+    template:
+      containers:
+        - name: function
+          imagePullPolicy: Always
+    #runtime: "Knative" # default to Knative

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -121,7 +121,7 @@ if [ "$with_openFuncAsync" = "true" ]; then
   fi
 fi
 
-if [ "$with_openFuncAsync" = "true" ]; then
+if [ "$with_openFuncAsync" = "true" ] || [ "$poor_network" = "false" ]; then
   kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.yaml
 else
   kubectl apply -f https://openfunction.sh1a.qingstor.com/cert-manager/v1.5.4/cert-manager.yaml


### PR DESCRIPTION
Signed-off-by: zhu733756 <zhu733756@kubesphere.io>

This pr aims to integrate CI test function:
- Basic test and verify CRD changes
- Binary build test
- Docker image build test
- Test the build process of the openfunction
- Install and uninstall the sync function
- Install and uninstall the async function

Files changed:
- Modify the file dockerfile by adding `ARG` for fast build test
- Add a few manifests for different functional tests
- Modify the file `deploy.sh` to fastly install the cert-manager
- Modify the file `Makefile` to change or add other cmdlines

Results:
- https://github.com/zhu733756/OpenFunction/actions/runs/1362362443 