### PR TITLE
support for adding labels and annotations to worklod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ help: ## Display this help.
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	kubectl kustomize config/default | sed -e '/creationTimestamp: null/d' | sed -e 's/openfunction-system/openfunction/g' | sed -e 's/openfunction\:latest/openfunction\:$(VERSION)/g' > config/bundle.yaml
+	kubectl kustomize config/default | sed -e '/creationTimestamp: null/d' | sed -e 's/openfunction-system/openfunction/g' | sed -e 's/openfunction\:latest/openfunction\:$(VERSION)/g' | sed -e 's/app.kubernetes.io\/version\: latest/app.kubernetes.io\/version\: $(VERSION)/g' > config/bundle.yaml
 	cat config/strategy/strategy.yaml >> config/bundle.yaml
 	cat config/domain/default-domain.yaml >> config/bundle.yaml
 

--- a/apis/core/v1alpha2/builder_types.go
+++ b/apis/core/v1alpha2/builder_types.go
@@ -95,7 +95,7 @@ type BuilderStatus struct {
 	// Output holds the results emitted from step definition of an output
 	//
 	// +optional
-	Output *Output `json:"output"`
+	Output *Output `json:"output,omitempty"`
 }
 
 //+genclient

--- a/apis/core/v1alpha2/function_types.go
+++ b/apis/core/v1alpha2/function_types.go
@@ -131,6 +131,12 @@ type ServingImpl struct {
 	Params map[string]string `json:"params,omitempty"`
 	// Parameters of asyncFunc runtime, must not be nil when runtime is OpenFuncAsync.
 	OpenFuncAsync *OpenFuncAsyncRuntime `json:"openFuncAsync,omitempty"`
+	// Labels that will be add to the workload.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+	// Annotations that will be add to the workload.
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
 	// Template describes the pods that will be created.
 	// The container named `function` is the container which is used to run the image built by the builder.
 	// If it is not set, the controller will automatically add one.

--- a/apis/core/v1alpha2/serving_types.go
+++ b/apis/core/v1alpha2/serving_types.go
@@ -133,6 +133,12 @@ type ServingSpec struct {
 	// Parameters of OpenFuncAsync runtime.
 	// +optional
 	OpenFuncAsync *OpenFuncAsyncRuntime `json:"openFuncAsync,omitempty"`
+	// Labels that will be add to the workload.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+	// Annotations that will be add to the workload.
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
 	// Template describes the pods that will be created.
 	// The container named `function` is the container which is used to run the image built by the builder.
 	// If it is not set, the controller will automatically add one.

--- a/apis/core/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/core/v1alpha2/zz_generated.deepcopy.go
@@ -869,6 +869,20 @@ func (in *ServingImpl) DeepCopyInto(out *ServingImpl) {
 		*out = new(OpenFuncAsyncRuntime)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Template != nil {
 		in, out := &in.Template, &out.Template
 		*out = new(v1.PodSpec)
@@ -957,6 +971,20 @@ func (in *ServingSpec) DeepCopyInto(out *ServingSpec) {
 		in, out := &in.OpenFuncAsync, &out.OpenFuncAsync
 		*out = new(OpenFuncAsyncRuntime)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	if in.Template != nil {
 		in, out := &in.Template, &out.Template

--- a/config/bundle.yaml
+++ b/config/bundle.yaml
@@ -9031,6 +9031,16 @@ spec:
                 description: Information needed to run a function. The serving step
                   will be skipped if `Serving` is nil.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations that will be add to the workload.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels that will be add to the workload.
+                    type: object
                   openFuncAsync:
                     description: Parameters of asyncFunc runtime, must not be nil
                       when runtime is OpenFuncAsync.
@@ -23156,6 +23166,11 @@ spec:
           spec:
             description: ServingSpec defines the desired state of Serving
             properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations that will be add to the workload.
+                type: object
               image:
                 description: Function image name
                 type: string
@@ -23167,6 +23182,11 @@ spec:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
+                type: object
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels that will be add to the workload.
                 type: object
               openFuncAsync:
                 description: Parameters of OpenFuncAsync runtime.
@@ -30745,6 +30765,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/name: openfunction-controller-manager
+    app.kubernetes.io/version: latest
     control-plane: controller-manager
   name: openfunction-controller-manager
   namespace: openfunction

--- a/config/crd/bases/core.openfunction.io_functions.yaml
+++ b/config/crd/bases/core.openfunction.io_functions.yaml
@@ -7497,6 +7497,16 @@ spec:
                 description: Information needed to run a function. The serving step
                   will be skipped if `Serving` is nil.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations that will be add to the workload.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels that will be add to the workload.
+                    type: object
                   openFuncAsync:
                     description: Parameters of asyncFunc runtime, must not be nil
                       when runtime is OpenFuncAsync.

--- a/config/crd/bases/core.openfunction.io_servings.yaml
+++ b/config/crd/bases/core.openfunction.io_servings.yaml
@@ -6972,6 +6972,11 @@ spec:
           spec:
             description: ServingSpec defines the desired state of Serving
             properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations that will be add to the workload.
+                type: object
               image:
                 description: Function image name
                 type: string
@@ -6983,6 +6988,11 @@ spec:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
+                type: object
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels that will be add to the workload.
                 type: object
               openFuncAsync:
                 description: Parameters of OpenFuncAsync runtime.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -12,6 +12,8 @@ metadata:
   namespace: system
   labels:
     control-plane: controller-manager
+    "app.kubernetes.io/name": "openfunction-controller-manager"
+    "app.kubernetes.io/version": latest
 spec:
   selector:
     matchLabels:

--- a/controllers/core/function_controller.go
+++ b/controllers/core/function_controller.go
@@ -400,7 +400,6 @@ func (r *FunctionReconciler) createServing(fn *openfunction.Function) error {
 		log.V(1).Info("Skip serving")
 		return nil
 	}
-
 	serving := &openfunction.Serving{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "serving-",
@@ -540,6 +539,8 @@ func (r *FunctionReconciler) createServingSpec(fn *openfunction.Function) openfu
 	if fn.Spec.Serving != nil {
 		spec.Params = fn.Spec.Serving.Params
 		spec.OpenFuncAsync = fn.Spec.Serving.OpenFuncAsync
+		spec.Labels = fn.Spec.Serving.Labels
+		spec.Annotations = fn.Spec.Serving.Annotations
 		spec.Template = fn.Spec.Serving.Template
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -481,7 +481,6 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/eclipse/paho.mqtt.golang v1.3.2/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -1077,7 +1076,6 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
-github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -2,4 +2,8 @@ package constants
 
 const (
 	FunctionLabel = "openfunction.io/function"
+
+	CommonLabelVersion = "app.kubernetes.io/version"
+
+	DefaultFunctionVersion = "latest"
 )

--- a/pkg/core/serving/knative/servingrun.go
+++ b/pkg/core/serving/knative/servingrun.go
@@ -15,6 +15,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openfunction/pkg/constants"
+
 	openfunction "github.com/openfunction/apis/core/v1alpha2"
 	"github.com/openfunction/pkg/core"
 	"github.com/openfunction/pkg/util"
@@ -24,8 +26,6 @@ const (
 	servingLabel = "openfunction.io/serving"
 
 	knativeService = "serving.knative.dev/service"
-
-	defaultVersion = "latest"
 )
 
 type servingRun struct {
@@ -175,14 +175,19 @@ func (r *servingRun) createService(s *openfunction.Serving) *kservingv1.Service 
 		template.Containers = append(template.Containers, *container)
 	}
 
+	version := constants.DefaultFunctionVersion
+	if s.Spec.Version != nil {
+		version = *s.Spec.Version
+	}
+	labels := map[string]string{
+		constants.CommonLabelVersion: version,
+	}
+	labels = util.AppendLabels(s.Spec.Labels, labels)
+
 	rand.Seed(time.Now().UnixNano())
 	serviceName := fmt.Sprintf("%s-ksvc-%s", s.Name, rand.String(5))
 	workloadName := serviceName
-	version := defaultVersion
-	if s.Spec.Version != nil {
-		version = strings.ReplaceAll(*s.Spec.Version, ".", "")
-	}
-	workloadName = fmt.Sprintf("%s-%s", workloadName, version)
+	workloadName = fmt.Sprintf("%s-%s", workloadName, strings.ReplaceAll(version, ".", ""))
 
 	service := kservingv1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -200,8 +205,10 @@ func (r *servingRun) createService(s *openfunction.Serving) *kservingv1.Service 
 			ConfigurationSpec: kservingv1.ConfigurationSpec{
 				Template: kservingv1.RevisionTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      workloadName,
-						Namespace: s.Namespace,
+						Name:        workloadName,
+						Namespace:   s.Namespace,
+						Labels:      labels,
+						Annotations: s.Spec.Annotations,
 					},
 					Spec: kservingv1.RevisionSpec{
 						PodSpec: *template,

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,6 +1,8 @@
 package util
 
-import "reflect"
+import (
+	"reflect"
+)
 
 func InterfaceIsNil(val interface{}) bool {
 
@@ -9,4 +11,20 @@ func InterfaceIsNil(val interface{}) bool {
 	}
 
 	return reflect.ValueOf(val).IsNil()
+}
+
+func AppendLabels(src, dest map[string]string) map[string]string {
+	if src == nil || len(src) == 0 {
+		return dest
+	}
+
+	if dest == nil {
+		dest = make(map[string]string)
+	}
+
+	for k, v := range src {
+		dest[k] = v
+	}
+
+	return dest
 }


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@kubesphere.io>

This pr is for issues #165 and #169 .

Users can add labels and annotations to the pod that runs the functions like this.

```
apiVersion: core.openfunction.io/v1alpha2
kind: Function
metadata:
  name: function-sample-serving-only
spec:
  version: "v1.0.0"
  image: "openfunctiondev/sample-go-func:latest"
  #port: 8080 # default to 8080
  serving:
    labels:
      app: openfunction
    annotations:
      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
    runtime: Knative
    template:
      containers:
        - name: function
          imagePullPolicy: Always
```

The `app.kubernetes.io/version` label will be added to the pod that runs the functions by default.
The `app.kubernetes.io/name` label is only added to the openfunction controller.