### PR TITLE
remove the imageCredentials in e2e samples

### DIFF
--- a/config/samples/function-bindings-sample-serving-only.yaml
+++ b/config/samples/function-bindings-sample-serving-only.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   version: "v1.0.0"
   image: openfunctiondev/v1beta1-output-target:latest
-  imageCredentials:
-    name: push-secret
   serving:
     runtime: Async
     inputs:
@@ -40,8 +38,6 @@ metadata:
 spec:
   version: "v1.0.0"
   image: openfunctiondev/v1beta1-bindings:latest
-  imageCredentials:
-    name: push-secret
   serving:
     template:
       containers:

--- a/config/samples/function-knative-with-dapr-serving-only.yaml
+++ b/config/samples/function-knative-with-dapr-serving-only.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   version: "v1.0.0"
   image: openfunctiondev/v1beta1-output-target:latest
-  imageCredentials:
-    name: push-secret
   serving:
     runtime: Async
     inputs:
@@ -40,8 +38,6 @@ metadata:
 spec:
   version: "v1.0.0"
   image: "openfunctiondev/v1beta1-sample-knative-dapr:latest"
-  imageCredentials:
-    name: push-secret
   port: 8080 # default to 8080
   serving:
     scaleOptions:

--- a/config/samples/function-pubsub-sample-serving-only.yaml
+++ b/config/samples/function-pubsub-sample-serving-only.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   version: "v1.0.0"
   image: openfunctiondev/v1beta1-autoscaling-producer:latest
-  imageCredentials:
-    name: push-secret
   serving:
     template:
       containers:
@@ -47,8 +45,6 @@ metadata:
 spec:
   version: "v1.0.0"
   image: openfunctiondev/v1beta1-autoscaling-subscriber:latest
-  imageCredentials:
-    name: push-secret
   serving:
     runtime: "Async"
     scaleOptions:


### PR DESCRIPTION
Signed-off-by: laminar <fangtian@kubesphere.io>