### PR TITLE
fix issue #164

### DIFF
--- a/apis/events/v1alpha1/eventsource_types.go
+++ b/apis/events/v1alpha1/eventsource_types.go
@@ -91,7 +91,7 @@ type EventSourceStatus struct {
 //+kubebuilder:resource:shortName=es
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="EventBus",type=string,JSONPath=`.spec.eventBus`
-//+kubebuilder:printcolumn:name="Sink",type=string,JSONPath=`.spec.sink.ref.name`
+//+kubebuilder:printcolumn:name="Sink",type=string,JSONPath=`.spec.sink.uri`
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[-1].type"
 
 // EventSource is the Schema for the eventsources API

--- a/config/bundle.yaml
+++ b/config/bundle.yaml
@@ -1101,7 +1101,7 @@ spec:
     - jsonPath: .spec.eventBus
       name: EventBus
       type: string
-    - jsonPath: .spec.sink.ref.name
+    - jsonPath: .spec.sink.uri
       name: Sink
       type: string
     - jsonPath: .status.conditions[-1].type

--- a/config/crd/bases/events.openfunction.io_eventsources.yaml
+++ b/config/crd/bases/events.openfunction.io_eventsources.yaml
@@ -22,7 +22,7 @@ spec:
     - jsonPath: .spec.eventBus
       name: EventBus
       type: string
-    - jsonPath: .spec.sink.ref.name
+    - jsonPath: .spec.sink.uri
       name: Sink
       type: string
     - jsonPath: .status.conditions[-1].type

--- a/controllers/events/event.go
+++ b/controllers/events/event.go
@@ -228,6 +228,8 @@ func createSinkComponent(ctx context.Context, c client.Client, log logr.Logger, 
 		namespace = sink.Ref.Namespace
 	}
 
+	sink.Uri = &url
+
 	component := &componentsv1alpha1.Component{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf(SinkComponentNameTmpl, resource.GetName(), namespace),


### PR DESCRIPTION
1. fix issue #164 
2. when EventSource is configured with the `spec.sink` field, use `spec.sink.uri` to carry the final URL address.

Signed-off-by: laminar <fangtian@kubesphere.io>