### PR TITLE
Add e2e testing ability for local environments

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -180,7 +180,6 @@ jobs:
           helm repo add nats https://nats-io.github.io/k8s/helm/charts/
           helm install nats nats/nats
           helm install stan nats/stan --set stan.nats.url=nats://nats:4222
-
           # deploy the eventbus backend nats streaming
           while /bin/true; do
             nats_status=`kubectl get pod nats-0 -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'`
@@ -193,7 +192,6 @@ jobs:
               continue
             fi
           done
-
           bash "${GITHUB_WORKSPACE}"/.github/workflows/e2e-test.sh events
 
       - name: Output debug info

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,23 @@ clean:
 	rm -rf config/samples/function-sample-dev.yaml
 	docker rmi `docker image ls | sed -e 's/[ ][ ]*/\t/g' | cut -f 2,3 | grep none | cut -f 2 | tr "\n" " "`  2>/dev/null
 
+##@ E2E test
+
+e2e: skywalking-e2e yq
+	$(E2E) run -c test/e2e.yaml
+
+e2e-knative: skywalking-e2e yq
+	$(E2E) run -c test/knative-runtime/e2e.yaml
+
+e2e-async: skywalking-e2e yq
+	$(E2E) run -c test/async-runtime/e2e.yaml
+
+e2e-plugin: skywalking-e2e yq
+	$(E2E) run -c test/plugin/e2e.yaml
+
+e2e-events: skywalking-e2e yq
+	$(E2E) run -c test/events/e2e.yaml
+
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
@@ -140,6 +157,14 @@ controller-gen: ## Download controller-gen locally if necessary.
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+
+E2E = $(shell pwd)/bin/e2e
+skywalking-e2e: ## Download skywalking-e2e locally if necessary.
+	$(call go-get-tool,$(E2E),github.com/apache/skywalking-infra-e2e/cmd/e2e@2a33478)
+
+YQ = $(shell pwd)/bin/yq
+yq: ## Download yq locally if necessary.
+	$(call go-get-tool,$(YQ),github.com/mikefarah/yq/v4@latest)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/docs/development/development-workflow.md
+++ b/docs/development/development-workflow.md
@@ -11,14 +11,14 @@ Per Go's [workspace instructions](https://golang.org/doc/code.html#Workspaces), 
 
 Define a local working directory:
 
-```
+```shell
 export working_dir=$GOPATH/src/openfunction.io
 export user={your github profile name}
 ```
 
 Create your clone locally:
 
-```
+```shell
 mkdir -p $working_dir
 cd $working_dir
 git clone https://github.com/$user/OpenFunction.git
@@ -34,7 +34,7 @@ git remote -v
 
 ## Step 3. Keep your branch in sync
 
-```
+```shell
 git fetch upstream
 git checkout main
 git rebase upstream/main
@@ -44,7 +44,7 @@ git rebase upstream/main
 
 Create a branch from master:
 
-```
+```shell
 git checkout -b myfeature
 ```
 
@@ -61,13 +61,47 @@ Currently, the make rules only contain simple checks such as vet, unit test, wil
 
 ### Run and test
 
-```
+> Run `make help` for additional information on these make targets.
+
+```shell
 make all
 # Run every unit test
 make test
 ```
 
-Run `make help` for additional information on these make targets.
+### E2E test
+
+We recommend using the following commands for e2e testing:
+
+You need to first look at the `test/e2e_env` file, which serves to provide the necessary environment variables for the e2e testing process. You **must complete** the configuration of these environment variables before you can run the e2e test.
+
+```shell
+# Your dockerhub username
+DOCKERHUB_USERNAME=
+# Your dockerhub password
+DOCKERHUB_PASSWORD=
+# Your dockerhub repository name
+DOCKERHUB_REPO_PREFIX=
+```
+
+You can run all e2e tests with a single command:
+
+```shell
+make e2e
+```
+
+You can also run e2e test on individual functions:
+
+```shell
+# e2e testing for knative-runtime
+make e2e-knative
+# e2e testing for async-runtime
+make e2e-async
+# e2e testing for plugin functionality
+make e2e-plugin
+# e2e testing for events-framework functionality
+make e2e-events
+```
 
 ## Step 5. Development in new branch
 
@@ -75,7 +109,7 @@ Run `make help` for additional information on these make targets.
 
 After the test is completed, it is a good practice to keep your local in sync with upstream to avoid conflicts.
 
-```
+```shell
 # Rebase your master branch of your local repo.
 git checkout main
 git rebase upstream/main
@@ -93,7 +127,7 @@ cd hack && bash generate-cert.sh
 
 ### Commit local changes
 
-```
+```shell
 git add <file>
 git commit -s -m "add your description"
 ```
@@ -102,7 +136,7 @@ git commit -s -m "add your description"
 
 When ready to review (or just to establish an offsite backup of your work), push your branch to your fork on GitHub:
 
-```
+```shell
 git push -f ${your_remote_name} myfeature
 ```
 

--- a/test/async-runtime/bindings/expected.data.yaml
+++ b/test/async-runtime/bindings/expected.data.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+async-bindings: success

--- a/test/async-runtime/bindings/manifests.yaml
+++ b/test/async-runtime/bindings/manifests.yaml
@@ -1,0 +1,138 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: core.openfunction.io/v1beta1
+kind: Function
+metadata:
+  name: e2e-v1beta1-kafka-input
+spec:
+  version: "v1.0.0"
+  image: "openfunctiondev/e2e-v1beta1-kafka-input:latest"
+#  imageCredentials:
+#    name: push-secret
+#  build:
+#    builder: openfunction/builder-go:latest
+#    env:
+#      FUNC_NAME: "HandleKafkaInput"
+#      FUNC_CLEAR_SOURCE: "true"
+#    srcRepo:
+#      url: "https://github.com/OpenFunction/samples.git"
+#      sourceSubPath: "functions/async/bindings/kafka-input"
+#      revision: "main"
+  serving:
+    runtime: async
+    scaleOptions:
+      minReplicas: 0
+      maxReplicas: 10
+      keda:
+        scaledObject:
+          pollingInterval: 15
+          minReplicaCount: 0
+          maxReplicaCount: 10
+          cooldownPeriod: 60
+          advanced:
+            horizontalPodAutoscalerConfig:
+              behavior:
+                scaleDown:
+                  stabilizationWindowSeconds: 45
+                  policies:
+                    - type: Percent
+                      value: 50
+                      periodSeconds: 15
+                scaleUp:
+                  stabilizationWindowSeconds: 0
+    triggers:
+      - type: kafka
+        metadata:
+          topic: bindings
+          bootstrapServers: kafka-server-kafka-brokers.default.svc:9092
+          consumerGroup: kafka-input
+          lagThreshold: "20"
+    inputs:
+      - name: greeting
+        component: target-topic
+    bindings:
+      target-topic:
+        type: bindings.kafka
+        version: v1
+        metadata:
+          - name: brokers
+            value: "kafka-server-kafka-brokers:9092"
+          - name: topics
+            value: "bindings"
+          - name: consumerGroup
+            value: "kafka-input"
+          - name: publishTopic
+            value: "bindings"
+          - name: authRequired
+            value: "false"
+    template:
+      containers:
+        - name: function
+          imagePullPolicy: Always
+---
+apiVersion: core.openfunction.io/v1beta1
+kind: Function
+metadata:
+  name: e2e-v1beta1-cron-in-kafka-out
+spec:
+  version: "v2.0.0"
+  image: "openfunctiondev/e2e-v1beta1-cron-in-kafka-out:latest"
+  imageCredentials:
+    name: push-secret
+  build:
+    builder: openfunction/builder-go:latest
+    env:
+      FUNC_NAME: "HandleCronInput"
+      FUNC_CLEAR_SOURCE: "true"
+    srcRepo:
+      url: "https://github.com/OpenFunction/samples.git"
+      sourceSubPath: "functions/async/bindings/cron-input-kafka-output"
+      revision: "main"
+  serving:
+    template:
+      containers:
+        - name: function
+          imagePullPolicy: Always
+    runtime: "async"
+    inputs:
+      - name: cron
+        component: cron
+    outputs:
+      - name: sample
+        component: kafka-server
+        operation: "create"
+    bindings:
+      cron:
+        type: bindings.cron
+        version: v1
+        metadata:
+          - name: schedule
+            value: "@every 2s"
+      kafka-server:
+        type: bindings.kafka
+        version: v1
+        metadata:
+          - name: brokers
+            value: "kafka-server-kafka-brokers:9092"
+          - name: topics
+            value: "bindings"
+          - name: consumerGroup
+            value: "bindings-with-output"
+          - name: publishTopic
+            value: "bindings"
+          - name: authRequired
+            value: "false"

--- a/test/async-runtime/bindings/verify.sh
+++ b/test/async-runtime/bindings/verify.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+export KUBECONFIG=/tmp/e2e-k8s.config
+
+MANIFESTS_PATH="./test/async-runtime/bindings/manifests.yaml"
+
+if [ "${DOCKERHUB_REPO_PREFIX}" ]; then
+  declare -a FUNCTIONS=("e2e-v1beta1-kafka-input" "e2e-v1beta1-cron-in-kafka-out")
+  for fn in "${FUNCTIONS[@]}";do
+    IMAGE_NAME=${DOCKERHUB_REPO_PREFIX}/$(NAME=${fn} ./bin/yq e 'select(.metadata.name == env(NAME) ).spec.image' ${MANIFESTS_PATH}|awk -F\/ '{ print $2 }') NAME=${fn} ./bin/yq -i e 'select(.metadata.name == env(NAME)).spec.image |= env(IMAGE_NAME)' ${MANIFESTS_PATH}
+  done
+fi
+
+kubectl apply -f ${MANIFESTS_PATH} > /dev/null 2>&1
+
+kubectl logs $(kubectl get po -l openfunction.io/serving=$(kubectl get functions e2e-v1beta1-kafka-input -o jsonpath='{.status.serving.resourceRef}') \
+  -o jsonpath='{.items[0].metadata.name}') function |grep "Hello" > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+  echo "async-bindings: success" | ./bin/yq
+  kubectl delete -f ${MANIFESTS_PATH} > /dev/null 2>&1
+fi

--- a/test/async-runtime/e2e.yaml
+++ b/test/async-runtime/e2e.yaml
@@ -1,0 +1,89 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+setup:
+  env: kind
+  file: ../kind.yaml
+  init-system-environment: ../e2e_env
+  steps:
+    - name: install helm
+      command: |
+        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+    - name: install kafka operator
+      command: |
+        helm repo add strimzi https://strimzi.io/charts/
+        helm install kafka-operator -n default strimzi/strimzi-kafka-operator
+
+    - name: setup kafka
+      path: ../kafka.yaml
+
+    - name: create secret
+      command: |
+        kubectl create secret docker-registry push-secret --docker-server="https://index.docker.io/v1/" --docker-username=${DOCKERHUB_USERNAME} --docker-password=${DOCKERHUB_PASSWORD}
+
+    - name: install ofn
+      command: |
+        wget -c  https://github.com/OpenFunction/cli/releases/latest/download/ofn_linux_amd64.tar.gz -O - | tar -xz
+        chmod +x ofn && mv ofn /usr/local/bin/
+
+    - name: install OpenFunction
+      command: |
+        ofn install --all --version latest
+        kubectl patch deployments.apps -n openfunction openfunction-controller-manager -p '{"spec":{"template":{"spec":{"containers":[{"name":"openfunction","image":"openfunction-dev:latest","imagePullPolicy":"IfNotPresent"}]}}}}'
+      wait:
+        - namespace: openfunction
+          resource: pod
+          label-selector: control-plane=controller-manager
+          for: condition=Ready
+
+    - name: setup build strategy
+      path: ../../config/strategy/build-strategy.yaml
+
+    - name: setup domain
+      path: ../../config/domain/default-domain.yaml
+
+  kind:
+    import-images:
+      - openfunction-dev:latest
+
+  timeout: 30m
+
+cleanup:
+  # always never success failure
+  on: success
+
+#trigger:
+#  action: "http"
+#  interval: 3s
+#  times: 10
+#  url: http://127.0.0.1:80
+#  method: GET
+
+verify:
+  # verify with retry strategy
+  retry:
+    # max retry count
+    count: 60
+    # the interval between two attempts, e.g. 10s, 1m.
+    interval: 10s
+  cases:
+      # async-runtime bindings sample test
+    - query: bash test/async-runtime/bindings/verify.sh
+      expected: bindings/expected.data.yaml
+      # async-runtime pubsub sample test
+    - query: bash test/async-runtime/pubsub/verify.sh
+      expected: pubsub/expected.data.yaml

--- a/test/async-runtime/pubsub/expected.data.yaml
+++ b/test/async-runtime/pubsub/expected.data.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+async-pubsub: success

--- a/test/async-runtime/pubsub/manifests.yaml
+++ b/test/async-runtime/pubsub/manifests.yaml
@@ -1,0 +1,137 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: producer
+  labels:
+    app: producer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: producer
+  template:
+    metadata:
+      labels:
+        app: producer
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "producer"
+        dapr.io/app-port: "60034"
+        dapr.io/log-as-json: "true"
+        dapr.io/app-protocol: "grpc"
+    spec:
+      containers:
+        - name: producer
+          image: openfunctiondev/v1beta1-autoscaling-producer:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PUBSUB_NAME
+              value: "autoscaling-producer"
+            - name: TOPIC_NAME
+              value: "pubsub"
+            - name: NUMBER_OF_PUBLISHERS
+              value: "20"
+          ports:
+            - containerPort: 60034
+              name: function-port
+              protocol: TCP
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: autoscaling-producer
+spec:
+  type: pubsub.kafka
+  version: v1
+  metadata:
+    - name: brokers
+      value: "kafka-server-kafka-brokers:9092"
+    - name: consumerGroup
+      value: "producer"
+    - name: authRequired
+      value: "false"
+    - name: allowedTopics
+      value: "pubsub"
+---
+apiVersion: core.openfunction.io/v1beta1
+kind: Function
+metadata:
+  name: e2e-v1beta1-subscriber
+spec:
+  version: "v2.0.0"
+  image: "openfunctiondev/e2e-v1beta1-subscriber:latest"
+  imageCredentials:
+    name: push-secret
+  build:
+    builder: openfunction/builder-go:latest
+    env:
+      FUNC_NAME: "Subscriber"
+      FUNC_CLEAR_SOURCE: "true"
+    srcRepo:
+      url: "https://github.com/OpenFunction/samples.git"
+      sourceSubPath: "functions/async/pubsub/subscriber"
+      revision: "main"
+  serving:
+    runtime: "async"
+    scaleOptions:
+      keda:
+        scaledObject:
+          pollingInterval: 15
+          minReplicaCount: 0
+          maxReplicaCount: 10
+          cooldownPeriod: 60
+          advanced:
+            horizontalPodAutoscalerConfig:
+              behavior:
+                scaleDown:
+                  stabilizationWindowSeconds: 45
+                  policies:
+                    - type: Percent
+                      value: 50
+                      periodSeconds: 15
+                scaleUp:
+                  stabilizationWindowSeconds: 0
+    triggers:
+      - type: kafka
+        metadata:
+          topic: "pubsub"
+          bootstrapServers: kafka-server-kafka-brokers.default.svc.cluster.local:9092
+          consumerGroup: autoscaling-subscriber
+          lagThreshold: "10"
+    template:
+      containers:
+        - name: function
+          imagePullPolicy: Always
+    inputs:
+      - name: producer
+        component: kafka-server
+        topic: "pubsub"
+    pubsub:
+      kafka-server:
+        type: pubsub.kafka
+        version: v1
+        metadata:
+          - name: brokers
+            value: "kafka-server-kafka-brokers:9092"
+          - name: authRequired
+            value: "false"
+          - name: allowedTopics
+            value: "pubsub"
+          - name: consumerID
+            value: "autoscaling-subscriber"

--- a/test/async-runtime/pubsub/verify.sh
+++ b/test/async-runtime/pubsub/verify.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+export KUBECONFIG=/tmp/e2e-k8s.config
+
+MANIFESTS_PATH="./test/async-runtime/pubsub/manifests.yaml"
+
+if [ "${DOCKERHUB_REPO_PREFIX}" ]; then
+  declare -a FUNCTIONS=("e2e-v1beta1-subscriber")
+  for fn in "${FUNCTIONS[@]}";do
+    IMAGE_NAME=${DOCKERHUB_REPO_PREFIX}/$(NAME=${fn} ./bin/yq e 'select(.metadata.name == env(NAME) ).spec.image' ${MANIFESTS_PATH}|awk -F\/ '{ print $2 }') NAME=${fn} ./bin/yq -i e 'select(.metadata.name == env(NAME)).spec.image |= env(IMAGE_NAME)' ${MANIFESTS_PATH}
+  done
+fi
+
+kubectl apply -f ${MANIFESTS_PATH} > /dev/null 2>&1
+
+rec=$(kubectl logs $(kubectl get po -l openfunction.io/serving=$(kubectl get functions e2e-v1beta1-subscriber -o jsonpath='{.status.serving.resourceRef}') -o jsonpath='{.items[0].metadata.name}') function |grep "event - Data"|wc -l)
+if [ $rec -gt 0 ]; then
+  replicas=`kubectl get deploy -l openfunction.io/serving=$(kubectl get functions e2e-v1beta1-subscriber -o jsonpath='{.status.serving.resourceRef}') -o jsonpath='{.items[0].spec.replicas}'` > /dev/null 2>&1
+  if [ $replicas -gt 1 ]; then
+    echo "async-pubsub: success" | ./bin/yq
+    kubectl delete -f ${MANIFESTS_PATH} > /dev/null 2>&1
+  fi
+fi

--- a/test/e2e.yaml
+++ b/test/e2e.yaml
@@ -1,0 +1,107 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+setup:
+  env: kind
+  file: ./kind.yaml
+  init-system-environment: ./e2e_env
+  steps:
+    - name: install helm
+      command: |
+        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+    - name: install kafka operator
+      command: |
+        helm repo add strimzi https://strimzi.io/charts/
+        helm install kafka-operator -n default strimzi/strimzi-kafka-operator
+
+    - name: setup kafka
+      path: ./kafka.yaml
+
+    - name: setup nats streaming
+      command: |
+        helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+        helm install nats nats/nats
+        helm install stan nats/stan --set stan.nats.url=nats://nats:4222
+
+    - name: create secret
+      command: |
+        kubectl create secret docker-registry push-secret --docker-server="https://index.docker.io/v1/" --docker-username=${DOCKERHUB_USERNAME} --docker-password=${DOCKERHUB_PASSWORD}
+
+    - name: install ofn
+      command: |
+        wget -c  https://github.com/OpenFunction/cli/releases/latest/download/ofn_linux_amd64.tar.gz -O - | tar -xz
+        chmod +x ofn && mv ofn /usr/local/bin/
+
+    - name: install OpenFunction
+      command: |
+        ofn install --all --version latest
+        kubectl patch deployments.apps -n openfunction openfunction-controller-manager -p '{"spec":{"template":{"spec":{"containers":[{"name":"openfunction","image":"openfunction-dev:latest","imagePullPolicy":"IfNotPresent"}]}}}}'
+      wait:
+        - namespace: openfunction
+          resource: pod
+          label-selector: control-plane=controller-manager
+          for: condition=Ready
+
+    - name: setup build strategy
+      path: ../config/strategy/build-strategy.yaml
+
+    - name: setup domain
+      path: ../config/domain/default-domain.yaml
+
+  kind:
+    import-images:
+      - openfunction-dev:latest
+
+  timeout: 30m
+
+cleanup:
+  # always never success failure
+  on: success
+
+#trigger:
+#  action: "http"
+#  interval: 3s
+#  times: 10
+#  url: http://127.0.0.1:80
+#  method: GET
+
+verify:
+  # verify with retry strategy
+  retry:
+    # max retry count
+    count: 60
+    # the interval between two attempts, e.g. 10s, 1m.
+    interval: 10s
+  cases:
+      # knative-runtime knative sample test
+    - query: bash test/knative-runtime/knative/verify.sh
+      expected: knative-runtime/knative/expected.data.yaml
+      # knative-runtime knative with dapr sample test
+    - query: bash test/knative-runtime/knative-dapr/verify.sh
+      expected: knative-runtime/knative-dapr/expected.data.yaml
+      # async-runtime bindings sample test
+    - query: bash test/async-runtime/bindings/verify.sh
+      expected: async-runtime/bindings/expected.data.yaml
+      # async-runtime pubsub sample test
+    - query: bash test/async-runtime/pubsub/verify.sh
+      expected: async-runtime/pubsub/expected.data.yaml
+      # plugin sample test
+    - query: bash test/plugin/verify.sh
+      expected: plugin/expected.data.yaml
+      # events api sample test
+    - query: bash test/events/verify.sh
+      expected: events/expected.data.yaml

--- a/test/e2e_env
+++ b/test/e2e_env
@@ -1,0 +1,19 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+DOCKERHUB_USERNAME=
+DOCKERHUB_PASSWORD=
+DOCKERHUB_REPO_PREFIX=

--- a/test/events/e2e.yaml
+++ b/test/events/e2e.yaml
@@ -1,0 +1,92 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+setup:
+  env: kind
+  file: ../kind.yaml
+  init-system-environment: ../e2e_env
+  steps:
+    - name: install helm
+      command: |
+        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+    - name: install kafka operator
+      command: |
+        helm repo add strimzi https://strimzi.io/charts/
+        helm install kafka-operator -n default strimzi/strimzi-kafka-operator
+
+    - name: setup kafka
+      path: ../kafka.yaml
+
+    - name: setup nats streaming
+      command: |
+        helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+        helm install nats nats/nats
+        helm install stan nats/stan --set stan.nats.url=nats://nats:4222
+
+    - name: create secret
+      command: |
+        kubectl create secret docker-registry push-secret --docker-server="https://index.docker.io/v1/" --docker-username=${DOCKERHUB_USERNAME} --docker-password=${DOCKERHUB_PASSWORD}
+
+    - name: install ofn
+      command: |
+        wget -c  https://github.com/OpenFunction/cli/releases/latest/download/ofn_linux_amd64.tar.gz -O - | tar -xz
+        chmod +x ofn && mv ofn /usr/local/bin/
+
+    - name: install OpenFunction
+      command: |
+        ofn install --all --version latest
+        kubectl patch deployments.apps -n openfunction openfunction-controller-manager -p '{"spec":{"template":{"spec":{"containers":[{"name":"openfunction","image":"openfunction-dev:latest","imagePullPolicy":"IfNotPresent"}]}}}}'
+      wait:
+        - namespace: openfunction
+          resource: pod
+          label-selector: control-plane=controller-manager
+          for: condition=Ready
+
+    - name: setup build strategy
+      path: ../../config/strategy/build-strategy.yaml
+
+    - name: setup domain
+      path: ../../config/domain/default-domain.yaml
+
+  kind:
+    import-images:
+      - openfunction-dev:latest
+
+  timeout: 30m
+
+cleanup:
+  # always never success failure
+  on: success
+
+#trigger:
+#  action: "http"
+#  interval: 3s
+#  times: 10
+#  url: http://127.0.0.1:80
+#  method: GET
+
+verify:
+  # verify with retry strategy
+  retry:
+    # max retry count
+    count: 60
+    # the interval between two attempts, e.g. 10s, 1m.
+    interval: 10s
+  cases:
+      # events api sample test
+    - query: bash test/events/verify.sh
+      expected: expected.data.yaml

--- a/test/events/expected.data.yaml
+++ b/test/events/expected.data.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+events: success

--- a/test/events/manifests.yaml
+++ b/test/events/manifests.yaml
@@ -1,0 +1,140 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: core.openfunction.io/v1beta1
+kind: Function
+metadata:
+  name: e2e-v1beta1-cron-in-kafka-out
+spec:
+  version: "v2.0.0"
+  image: "openfunctiondev/e2e-v1beta1-cron-in-kafka-out:latest"
+#  imageCredentials:
+#    name: push-secret
+#  build:
+#    builder: openfunction/builder-go:latest
+#    env:
+#      FUNC_NAME: "HandleCronInput"
+#      FUNC_CLEAR_SOURCE: "true"
+#    srcRepo:
+#      url: "https://github.com/OpenFunction/samples.git"
+#      sourceSubPath: "functions/async/bindings/cron-input-kafka-output"
+#      revision: "main"
+  serving:
+    template:
+      containers:
+        - name: function
+          imagePullPolicy: Always
+    runtime: "async"
+    inputs:
+      - name: cron
+        component: cron
+    outputs:
+      - name: sample
+        component: kafka-server
+        operation: "create"
+    bindings:
+      cron:
+        type: bindings.cron
+        version: v1
+        metadata:
+          - name: schedule
+            value: "@every 2s"
+      kafka-server:
+        type: bindings.kafka
+        version: v1
+        metadata:
+          - name: brokers
+            value: "kafka-server-kafka-brokers:9092"
+          - name: topics
+            value: "events-sample"
+          - name: consumerGroup
+            value: "bindings-with-output"
+          - name: publishTopic
+            value: "events-sample"
+          - name: authRequired
+            value: "false"
+---
+apiVersion: core.openfunction.io/v1beta1
+kind: Function
+metadata:
+  name: sink-a
+spec:
+  version: "v1.0.0"
+  image: "openfunction/sink-sample:latest"
+  port: 8080
+  serving:
+    runtime: "knative"
+    template:
+      containers:
+        - name: function
+          imagePullPolicy: Always
+---
+apiVersion: core.openfunction.io/v1beta1
+kind: Function
+metadata:
+  name: sink-b
+spec:
+  version: "v1.0.0"
+  image: "openfunction/sink-sample:latest"
+  port: 8080
+  serving:
+    runtime: "knative"
+    template:
+      containers:
+        - name: function
+          imagePullPolicy: Always
+---
+apiVersion: events.openfunction.io/v1alpha1
+kind: EventBus
+metadata:
+  name: default
+spec:
+  natsStreaming:
+    natsURL: "nats://nats.default:4222"
+    natsStreamingClusterID: "stan"
+    subscriptionType: "queue"
+    durableSubscriptionName: "ImDurable"
+---
+apiVersion: events.openfunction.io/v1alpha1
+kind: EventSource
+metadata:
+  name: my-eventsource
+spec:
+  logLevel: "2"
+  eventBus: "default"
+  kafka:
+    sample-one:
+      brokers: "kafka-server-kafka-brokers.default.svc.cluster.local:9092"
+      topic: "events-sample"
+      authRequired: false
+  sink:
+    uri: "http://openfunction.io.svc.cluster.local/default/sink-a"
+---
+apiVersion: events.openfunction.io/v1alpha1
+kind: Trigger
+metadata:
+  name: my-trigger
+spec:
+  logLevel: "2"
+  eventBus: "default"
+  inputs:
+    inputDemo:
+      eventSource: "my-eventsource"
+      event: "sample-one"
+  subscribers:
+    - condition: inputDemo
+      sink:
+        uri: "http://openfunction.io.svc.cluster.local/default/sink-b"

--- a/test/events/verify.sh
+++ b/test/events/verify.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+export KUBECONFIG=/tmp/e2e-k8s.config
+
+MANIFESTS_PATH="./test/events/manifests.yaml"
+
+if [ "${DOCKERHUB_REPO_PREFIX}" ]; then
+  declare -a FUNCTIONS=("e2e-v1beta1-cron-in-kafka-out")
+  for fn in "${FUNCTIONS[@]}";do
+    IMAGE_NAME=${DOCKERHUB_REPO_PREFIX}/$(NAME=${fn} ./bin/yq e 'select(.metadata.name == env(NAME) ).spec.image' ${MANIFESTS_PATH}|awk -F\/ '{ print $2 }') NAME=${fn} ./bin/yq -i e 'select(.metadata.name == env(NAME)).spec.image |= env(IMAGE_NAME)' ${MANIFESTS_PATH}
+  done
+fi
+
+kubectl apply -f ${MANIFESTS_PATH} > /dev/null 2>&1
+
+kubectl logs $(kubectl get po -l openfunction.io/serving=$(kubectl get functions sink-a -o jsonpath='{.status.serving.resourceRef}') \
+  -o jsonpath='{.items[0].metadata.name}') function |grep "Hello" > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+  kubectl logs $(kubectl get po -l openfunction.io/serving=$(kubectl get functions sink-b -o jsonpath='{.status.serving.resourceRef}') \
+    -o jsonpath='{.items[0].metadata.name}') function |grep "Hello" > /dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    echo "events: success" | ./bin/yq
+    kubectl delete -f ${MANIFESTS_PATH} > /dev/null 2>&1
+  fi
+fi

--- a/test/kafka.yaml
+++ b/test/kafka.yaml
@@ -1,0 +1,106 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: kafka-server
+  namespace: default
+spec:
+  kafka:
+    version: 3.1.0
+    replicas: 1
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
+      inter.broker.protocol.version: "3.1"
+    storage:
+      type: ephemeral
+  zookeeper:
+    replicas: 1
+    storage:
+      type: ephemeral
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pubsub
+  namespace: default
+  labels:
+    strimzi.io/cluster: kafka-server
+spec:
+  partitions: 10
+  replicas: 1
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: bindings
+  namespace: default
+  labels:
+    strimzi.io/cluster: kafka-server
+spec:
+  partitions: 10
+  replicas: 1
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: knative-dapr
+  namespace: default
+  labels:
+    strimzi.io/cluster: kafka-server
+spec:
+  partitions: 10
+  replicas: 1
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: events-sample
+  namespace: default
+  labels:
+    strimzi.io/cluster: kafka-server
+spec:
+  partitions: 10
+  replicas: 1
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824

--- a/test/kind.yaml
+++ b/test/kind.yaml
@@ -1,0 +1,52 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# this config file contains all config fields with comments
+# NOTE: this is not a particularly useful config file
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+# patch the generated kubeadm config with some extra settings
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    kind: KubeletConfiguration
+    evictionHard:
+      nodefs.available: "0%"
+# patch it further using a JSON 6902 patch
+kubeadmConfigPatchesJSON6902:
+  - group: kubeadm.k8s.io
+    version: v1beta2
+    kind: ClusterConfiguration
+    patch: |
+      - op: add
+        path: /apiServer/certSANs/-
+        value: my-hostname
+# 1 control plane node (workder)
+nodes:
+  # the control plane node (worker) config
+  - role: control-plane
+#    image: kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9
+#    image: kindest/node:v1.22.7@sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166
+    image: kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c
+    extraPortMappings:
+      - containerPort: 31234
+        hostPort: 80
+        # optional: set the bind address on the host
+        # 0.0.0.0 is the current default
+        listenAddress: "127.0.0.1"
+        # optional: set the protocol to one of TCP, UDP, SCTP.
+        # TCP is the default
+        protocol: TCP

--- a/test/knative-runtime/e2e.yaml
+++ b/test/knative-runtime/e2e.yaml
@@ -1,0 +1,89 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+setup:
+  env: kind
+  file: ../kind.yaml
+  init-system-environment: ../e2e_env
+  steps:
+    - name: install helm
+      command: |
+        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+    - name: install kafka operator
+      command: |
+        helm repo add strimzi https://strimzi.io/charts/
+        helm install kafka-operator -n default strimzi/strimzi-kafka-operator
+
+    - name: setup kafka
+      path: ../kafka.yaml
+
+    - name: create secret
+      command: |
+        kubectl create secret docker-registry push-secret --docker-server="https://index.docker.io/v1/" --docker-username=${DOCKERHUB_USERNAME} --docker-password=${DOCKERHUB_PASSWORD}
+
+    - name: install ofn
+      command: |
+        wget -c  https://github.com/OpenFunction/cli/releases/latest/download/ofn_linux_amd64.tar.gz -O - | tar -xz
+        chmod +x ofn && mv ofn /usr/local/bin/
+
+    - name: install OpenFunction
+      command: |
+        ofn install --all --version latest
+        kubectl patch deployments.apps -n openfunction openfunction-controller-manager -p '{"spec":{"template":{"spec":{"containers":[{"name":"openfunction","image":"openfunction-dev:latest","imagePullPolicy":"IfNotPresent"}]}}}}'
+      wait:
+        - namespace: openfunction
+          resource: pod
+          label-selector: control-plane=controller-manager
+          for: condition=Ready
+
+    - name: setup build strategy
+      path: ../../config/strategy/build-strategy.yaml
+
+    - name: setup domain
+      path: ../../config/domain/default-domain.yaml
+
+  kind:
+    import-images:
+      - openfunction-dev:latest
+
+  timeout: 30m
+
+cleanup:
+  # always never success failure
+  on: success
+
+#trigger:
+#  action: "http"
+#  interval: 3s
+#  times: 10
+#  url: http://127.0.0.1:80
+#  method: GET
+
+verify:
+  # verify with retry strategy
+  retry:
+    # max retry count
+    count: 60
+    # the interval between two attempts, e.g. 10s, 1m.
+    interval: 10s
+  cases:
+      # knative-runtime knative sample test
+    - query: bash test/knative-runtime/knative/verify.sh
+      expected: knative/expected.data.yaml
+      # knative-runtime knative with dapr sample test
+    - query: bash test/knative-runtime/knative-dapr/verify.sh
+      expected: knative-dapr/expected.data.yaml

--- a/test/knative-runtime/knative-dapr/expected.data.yaml
+++ b/test/knative-runtime/knative-dapr/expected.data.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+knative-dapr: success

--- a/test/knative-runtime/knative-dapr/manifests.yaml
+++ b/test/knative-runtime/knative-dapr/manifests.yaml
@@ -1,0 +1,133 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: core.openfunction.io/v1beta1
+kind: Function
+metadata:
+  name: e2e-v1beta1-kafka-input
+spec:
+  version: "v1.0.0"
+  image: "openfunctiondev/e2e-v1beta1-kafka-input:latest"
+  imageCredentials:
+    name: push-secret
+  build:
+    builder: openfunction/builder-go:latest
+    env:
+      FUNC_NAME: "HandleKafkaInput"
+      FUNC_CLEAR_SOURCE: "true"
+    srcRepo:
+      url: "https://github.com/OpenFunction/samples.git"
+      sourceSubPath: "functions/async/bindings/kafka-input"
+      revision: "main"
+  serving:
+    runtime: async
+    scaleOptions:
+      minReplicas: 0
+      maxReplicas: 10
+      keda:
+        scaledObject:
+          pollingInterval: 15
+          minReplicaCount: 0
+          maxReplicaCount: 10
+          cooldownPeriod: 60
+          advanced:
+            horizontalPodAutoscalerConfig:
+              behavior:
+                scaleDown:
+                  stabilizationWindowSeconds: 45
+                  policies:
+                    - type: Percent
+                      value: 50
+                      periodSeconds: 15
+                scaleUp:
+                  stabilizationWindowSeconds: 0
+    triggers:
+      - type: kafka
+        metadata:
+          topic: knative-dapr
+          bootstrapServers: kafka-server-kafka-brokers.default.svc:9092
+          consumerGroup: kafka-input
+          lagThreshold: "10"
+    inputs:
+      - name: greeting
+        component: target-topic
+    bindings:
+      target-topic:
+        type: bindings.kafka
+        version: v1
+        metadata:
+          - name: brokers
+            value: "kafka-server-kafka-brokers:9092"
+          - name: topics
+            value: "knative-dapr"
+          - name: consumerGroup
+            value: "kafka-input"
+          - name: publishTopic
+            value: "knative-dapr"
+          - name: authRequired
+            value: "false"
+    template:
+      containers:
+        - name: function
+          imagePullPolicy: Always
+---
+apiVersion: core.openfunction.io/v1beta1
+kind: Function
+metadata:
+  name: e2e-v1beta1-function-front
+spec:
+  version: "v1.0.0"
+  image: "openfunctiondev/e2e-v1beta1-function-front:latest"
+  port: 8080 # default to 8080
+  imageCredentials:
+    name: push-secret
+  build:
+    builder: openfunction/builder-go:latest
+    env:
+      FUNC_NAME: "ForwardToKafka"
+      FUNC_CLEAR_SOURCE: "true"
+    srcRepo:
+      url: "https://github.com/OpenFunction/samples.git"
+      sourceSubPath: "functions/knative/with-output-binding"
+      revision: "main"
+  serving:
+    scaleOptions:
+      minReplicas: 0
+      maxReplicas: 5
+    runtime: knative
+    outputs:
+      - name: target
+        component: kafka-server
+        operation: "create"
+    bindings:
+      kafka-server:
+        type: bindings.kafka
+        version: v1
+        metadata:
+          - name: brokers
+            value: "kafka-server-kafka-brokers:9092"
+          - name: authRequired
+            value: "false"
+          - name: publishTopic
+            value: "knative-dapr"
+          - name: topics
+            value: "knative-dapr"
+          - name: consumerGroup
+            value: "function-front"
+    template:
+      containers:
+        - name: function
+          imagePullPolicy: Always

--- a/test/knative-runtime/knative-dapr/verify.sh
+++ b/test/knative-runtime/knative-dapr/verify.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+export KUBECONFIG=/tmp/e2e-k8s.config
+
+MANIFESTS_PATH="./test/knative-runtime/knative-dapr/manifests.yaml"
+
+if [ "${DOCKERHUB_REPO_PREFIX}" ]; then
+  declare -a FUNCTIONS=("e2e-v1beta1-kafka-input" "e2e-v1beta1-function-front")
+  for fn in "${FUNCTIONS[@]}";do
+    IMAGE_NAME=${DOCKERHUB_REPO_PREFIX}/$(NAME=${fn} ./bin/yq e 'select(.metadata.name == env(NAME) ).spec.image' ${MANIFESTS_PATH}|awk -F\/ '{ print $2 }') NAME=${fn} ./bin/yq -i e 'select(.metadata.name == env(NAME)).spec.image |= env(IMAGE_NAME)' ${MANIFESTS_PATH}
+  done
+fi
+
+kubectl port-forward -n ingress-nginx service/ingress-nginx-controller 8080:80 > /dev/null 2>&1 &
+
+kubectl apply -f ${MANIFESTS_PATH} > /dev/null 2>&1
+
+url=$(kubectl get fn e2e-v1beta1-function-front -o jsonpath='{.status.url}')
+if [ "$url" ]; then
+  res=$(curl -H "Host: openfunction.io.svc" -m 10 -o /dev/null -s -w %{http_code}"\n" -d '{"message":"Awesome OpenFunction!"}' -H "Content-Type: application/json" -X POST http://localhost:8080/default/e2e-v1beta1-function-front)
+  if test "$res" = "200"; then
+    kubectl logs $(kubectl get po -l openfunction.io/serving=$(kubectl get functions e2e-v1beta1-kafka-input -o jsonpath='{.status.serving.resourceRef}') \
+          -o jsonpath='{.items[0].metadata.name}') function |grep "Awesome OpenFunction" > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      echo "knative-dapr: success" | ./bin/yq
+      kubectl delete -f ${MANIFESTS_PATH} > /dev/null 2>&1
+    fi
+  fi
+fi
+
+pkill -9 -f "kubectl port-forward"

--- a/test/knative-runtime/knative/expected.data.yaml
+++ b/test/knative-runtime/knative/expected.data.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+knative: success

--- a/test/knative-runtime/knative/manifests.yaml
+++ b/test/knative-runtime/knative/manifests.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: core.openfunction.io/v1beta1
+kind: Function
+metadata:
+  name: e2e-v1beta1-knative
+spec:
+  version: "v1.0.0"
+  image: "openfunctiondev/e2e-v1beta1-knative:latest"
+  imageCredentials:
+    name: push-secret
+  port: 8080 # default to 8080
+  build:
+    builder: openfunction/builder-go:latest
+    env:
+      FUNC_NAME: "HelloWorld"
+      FUNC_CLEAR_SOURCE: "true"
+    srcRepo:
+      url: "https://github.com/OpenFunction/samples.git"
+      sourceSubPath: "functions/knative/hello-world-go"
+      revision: "main"
+  serving:
+    runtime: knative
+    template:
+      containers:
+        - name: function
+          imagePullPolicy: Always

--- a/test/knative-runtime/knative/verify.sh
+++ b/test/knative-runtime/knative/verify.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+export KUBECONFIG=/tmp/e2e-k8s.config
+
+MANIFESTS_PATH="./test/knative-runtime/knative/manifests.yaml"
+
+if [ "${DOCKERHUB_REPO_PREFIX}" ]; then
+  declare -a FUNCTIONS=("e2e-v1beta1-knative")
+  for fn in "${FUNCTIONS[@]}";do
+    IMAGE_NAME=${DOCKERHUB_REPO_PREFIX}/$(NAME=${fn} ./bin/yq e 'select(.metadata.name == env(NAME) ).spec.image' ${MANIFESTS_PATH}|awk -F\/ '{ print $2 }') NAME=${fn} ./bin/yq -i e 'select(.metadata.name == env(NAME)).spec.image |= env(IMAGE_NAME)' ${MANIFESTS_PATH}
+  done
+fi
+
+kubectl port-forward -n ingress-nginx service/ingress-nginx-controller 8080:80 > /dev/null 2>&1 &
+
+kubectl apply -f ${MANIFESTS_PATH} > /dev/null 2>&1
+
+url=$(kubectl get fn e2e-v1beta1-knative -o jsonpath='{.status.url}')
+if [ "$url" ]; then
+  res=$(curl -H "Host: openfunction.io.svc" -I -m 10 -o /dev/null -s -w %{http_code}"\n" http://localhost:8080/default/e2e-v1beta1-knative)
+  if test "$res" = "200"; then
+    echo "knative: success" | ./bin/yq
+    kubectl delete -f ${MANIFESTS_PATH} > /dev/null 2>&1
+  fi
+fi
+
+pkill -9 -f "kubectl port-forward"

--- a/test/plugin/e2e.yaml
+++ b/test/plugin/e2e.yaml
@@ -1,0 +1,83 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+setup:
+  env: kind
+  file: ../kind.yaml
+  init-system-environment: ../e2e_env
+  steps:
+    - name: install helm
+      command: |
+        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+    - name: install kafka operator
+      command: |
+        helm repo add strimzi https://strimzi.io/charts/
+        helm install kafka-operator -n default strimzi/strimzi-kafka-operator
+
+    - name: setup kafka
+      path: ../kafka.yaml
+
+    - name: create secret
+      command: |
+        kubectl create secret docker-registry push-secret --docker-server="https://index.docker.io/v1/" --docker-username=${DOCKERHUB_USERNAME} --docker-password=${DOCKERHUB_PASSWORD}
+
+    - name: install ofn
+      command: |
+        wget -c  https://github.com/OpenFunction/cli/releases/latest/download/ofn_linux_amd64.tar.gz -O - | tar -xz
+        chmod +x ofn && mv ofn /usr/local/bin/
+
+    - name: install OpenFunction
+      command: |
+        ofn install --all --version latest
+        kubectl patch deployments.apps -n openfunction openfunction-controller-manager -p '{"spec":{"template":{"spec":{"containers":[{"name":"openfunction","image":"openfunction-dev:latest","imagePullPolicy":"IfNotPresent"}]}}}}'
+      wait:
+        - namespace: openfunction
+          resource: pod
+          label-selector: control-plane=controller-manager
+          for: condition=Ready
+
+    - name: setup build strategy
+      path: ../../config/strategy/build-strategy.yaml
+
+  kind:
+    import-images:
+      - openfunction-dev:latest
+
+  timeout: 30m
+
+cleanup:
+  # always never success failure
+  on: success
+
+#trigger:
+#  action: "http"
+#  interval: 3s
+#  times: 10
+#  url: http://127.0.0.1:80
+#  method: GET
+
+verify:
+  # verify with retry strategy
+  retry:
+    # max retry count
+    count: 60
+    # the interval between two attempts, e.g. 10s, 1m.
+    interval: 10s
+  cases:
+      # plugin sample test
+    - query: bash test/plugin/verify.sh
+      expected: expected.data.yaml

--- a/test/plugin/expected.data.yaml
+++ b/test/plugin/expected.data.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+plugin: success

--- a/test/plugin/manifests.yaml
+++ b/test/plugin/manifests.yaml
@@ -1,0 +1,97 @@
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: core.openfunction.io/v1beta1
+kind: Function
+metadata:
+  name: e2e-v1beta1-plugins
+  annotations:
+    plugins: |
+      pre:
+      - plugin-custom
+      - plugin-example
+      post:
+      - plugin-custom
+      - plugin-example
+    plugins.tracing: |
+      # Switch for tracing, default to false
+      enabled: false
+      # Provider name can be set to "skywalking", "opentelemetry"
+      # A valid provider must be set if tracing is enabled.
+      provider:
+        name: "skywalking"
+        oapServer: "localhost:xxx"
+      # Custom tags to add to tracing
+      tags:
+        func: function-with-tracing
+        layer: faas
+        tag1: value1
+        tag2: value2
+      baggage:
+      # baggage key is `sw8-correlation` for skywalking and `baggage` for opentelemetry
+      # Correlation context for skywalking: https://skywalking.apache.org/docs/main/latest/en/protocols/skywalking-cross-process-correlation-headers-protocol-v1/
+      # baggage for opentelemetry: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/baggage/api.md
+      # W3C Baggage Specification/: https://w3c.github.io/baggage/
+        key: sw8-correlation # key should be baggage for opentelemetry
+        value: "base64(string key):base64(string value),base64(string key2):base64(string value2)"
+spec:
+  version: "v1.0.0"
+  image: "openfunctiondev/e2e-v1beta1-plugins:latest"
+  imageCredentials:
+    name: push-secret
+  build:
+    builder: openfunction/builder-go:latest
+    env:
+      FUNC_NAME: "HandleCronInput"
+      FUNC_CLEAR_SOURCE: "true"
+    srcRepo:
+      url: "https://github.com/OpenFunction/samples.git"
+      sourceSubPath: "functions/async/bindings/cron-input-kafka-output"
+      revision: "main"
+  serving:
+    template:
+      containers:
+        - name: function
+          imagePullPolicy: Always
+    runtime: "async"
+    inputs:
+      - name: cron
+        component: cron
+    outputs:
+      - name: sample
+        component: kafka-server
+        operation: "create"
+    bindings:
+      cron:
+        type: bindings.cron
+        version: v1
+        metadata:
+          - name: schedule
+            value: "@every 2s"
+      kafka-server:
+        type: bindings.kafka
+        version: v1
+        metadata:
+          - name: brokers
+            value: "kafka-server-kafka-brokers:9092"
+          - name: topics
+            value: "bindings"
+          - name: consumerGroup
+            value: "bindings-with-output"
+          - name: publishTopic
+            value: "bindings"
+          - name: authRequired
+            value: "false"

--- a/test/plugin/verify.sh
+++ b/test/plugin/verify.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+#
+# Copyright 2022 The OpenFunction Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+export KUBECONFIG=/tmp/e2e-k8s.config
+
+MANIFESTS_PATH="./test/plugin/manifests.yaml"
+
+if [ "${DOCKERHUB_REPO_PREFIX}" ]; then
+  declare -a FUNCTIONS=("e2e-v1beta1-plugins")
+  for fn in "${FUNCTIONS[@]}";do
+    IMAGE_NAME=${DOCKERHUB_REPO_PREFIX}/$(NAME=${fn} ./bin/yq e 'select(.metadata.name == env(NAME) ).spec.image' ${MANIFESTS_PATH}|awk -F\/ '{ print $2 }') NAME=${fn} ./bin/yq -i e 'select(.metadata.name == env(NAME)).spec.image |= env(IMAGE_NAME)' ${MANIFESTS_PATH}
+  done
+fi
+
+kubectl apply -f ${MANIFESTS_PATH} > /dev/null 2>&1
+
+kubectl logs $(kubectl get po -l openfunction.io/serving=$(kubectl get functions e2e-v1beta1-plugins -o jsonpath='{.status.serving.resourceRef}') \
+      -o jsonpath='{.items[0].metadata.name}') function |grep "Result: {\"sum\":2}" > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+  echo "plugin: success" | ./bin/yq
+  kubectl delete -f ${MANIFESTS_PATH} > /dev/null 2>&1
+fi


### PR DESCRIPTION
1. add `make e2e-knative` command for knative-runtime e2e testing.
2. add `make e2e-async` command for async-runtime e2e testing.
3. add `make e2e-plugin` command for plugin functionality e2e testing.
4. add `make e2e-events` command for events-framework functionality e2e testing.
5. add a one-click `make e2e-all` command for all the above e2e tests.
6. add docs.

Signed-off-by: laminar <fangtian@kubesphere.io>