### PR TITLE
Add non null judgment for sink

### DIFF
--- a/config/bundle.yaml
+++ b/config/bundle.yaml
@@ -15416,6 +15416,127 @@ status:
   conditions: []
   storedVersions: []
 ---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: openfunction-mutating-webhook-configuration
+  namespace: openfunction
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUROVENDQWgyZ0F3SUJBZ0lVUWNCUGt6MC90OTZ2dzJZV2F0S1JqRWZwaFJrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0tqRW9NQ1lHQTFVRUF3d2ZZMkV0YjNCbGJtWjFibU4wYVc5dUxYZGxZbWh2YjJzdGMyVnlkbWxqWlRBZQpGdzB5TWpBME1EY3dNelV3TURaYUZ3MHpNakEwTURRd016VXdNRFphTUNveEtEQW1CZ05WQkFNTUgyTmhMVzl3ClpXNW1kVzVqZEdsdmJpMTNaV0pvYjI5ckxYTmxjblpwWTJVd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUIKRHdBd2dnRUtBb0lCQVFEVXpZK1hZSmoxdS9sNmZvR1NiWEhaUDNhZklZN1lFRi9ZUk9sQ1V0Q2VBZ25CSDE4NwpqUk1hUVlTWmxMQTBBNEUxR0ZONzVqUU5KV3k5MVJkZmsxN1Z3RFlSa2lpUmg4bjNJbHpsbHQrQ3JKdWJsUHJmCkRFUVZuUkNTRW1Udnc5WmIvWkpXSXloRTNmN0dhckY4S3R3VVZXazNzTzB2Mk0wWXVvdGQxdjdUV3JmS0FBaUgKQjhNS0E2VTN6M0gyOSs0M1NkN1I5SW8vQzhuSFVHMkUrMDk5R3lhcnhRNUVkb2hkTkVCc05jbGprS0ZkNDRkKwpTdzRSVG56MFhIS1JILy9TM0hQMmUvd1ptRTBkb2E0N2VXdlVBay8waUxtMnY3Wk1CWUF2TmFDamVOd3BNNjJmCmpBVnd2YVBid0lIRGZBZHdRaU42bHhrbThIWHlsV0xEZDVnTEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCVEYKL0VFcGdsVGJOZ1VTYnhTS2c1bk1kMzMyZ3pBZkJnTlZIU01FR0RBV2dCVEYvRUVwZ2xUYk5nVVNieFNLZzVuTQpkMzMyZ3pBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCWTN5MWI0MC9sCm03bVJrek91YnRFSnNYWWUzYTFSYkx0eE4vNnQzOG1kNnlneWxVVzZ5WWxJTHBYdjc1ZlFIR3Z2cUhMREdJdmMKOG5VVCsrNUgrUHExaHZxeVV3azFUby9NODE2NkNDMHB2UVNERERMMkNYUzl5TWtrL25tQXBTV2l5aVhRT0cxRApyWEdSMk9BZFlYcFdaNHlzZFRqSGNCY2V1Z3Y0ZzJGOWtXSXJ1eDBCeExGdzE4YjVqSGI1dTltK1VnMDZZMTd6ClNxbWhza0dYajVLWTkwWXAwZUpnUHBWRjNPSzhIWGRYbVlTcjdjOXp4bWc1NGR4K0QxcnMveUc1SjJBN1NTU3gKM1BnL05zbXZvY2QzdFp3K1ZyUnkycC9GbXZ4aUdQOHM0MFBQMTVjdkZMcnM0REVZRFVtekxXNmtqVW9aK041bgpiZFFGM24rZ045ZnkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    service:
+      name: openfunction-webhook-service
+      namespace: openfunction
+      path: /mutate-core-openfunction-io-v1beta1-function
+  failurePolicy: Fail
+  name: mfunctions.of.io
+  rules:
+  - apiGroups:
+    - core.openfunction.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - functions
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUROVENDQWgyZ0F3SUJBZ0lVUWNCUGt6MC90OTZ2dzJZV2F0S1JqRWZwaFJrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0tqRW9NQ1lHQTFVRUF3d2ZZMkV0YjNCbGJtWjFibU4wYVc5dUxYZGxZbWh2YjJzdGMyVnlkbWxqWlRBZQpGdzB5TWpBME1EY3dNelV3TURaYUZ3MHpNakEwTURRd016VXdNRFphTUNveEtEQW1CZ05WQkFNTUgyTmhMVzl3ClpXNW1kVzVqZEdsdmJpMTNaV0pvYjI5ckxYTmxjblpwWTJVd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUIKRHdBd2dnRUtBb0lCQVFEVXpZK1hZSmoxdS9sNmZvR1NiWEhaUDNhZklZN1lFRi9ZUk9sQ1V0Q2VBZ25CSDE4NwpqUk1hUVlTWmxMQTBBNEUxR0ZONzVqUU5KV3k5MVJkZmsxN1Z3RFlSa2lpUmg4bjNJbHpsbHQrQ3JKdWJsUHJmCkRFUVZuUkNTRW1Udnc5WmIvWkpXSXloRTNmN0dhckY4S3R3VVZXazNzTzB2Mk0wWXVvdGQxdjdUV3JmS0FBaUgKQjhNS0E2VTN6M0gyOSs0M1NkN1I5SW8vQzhuSFVHMkUrMDk5R3lhcnhRNUVkb2hkTkVCc05jbGprS0ZkNDRkKwpTdzRSVG56MFhIS1JILy9TM0hQMmUvd1ptRTBkb2E0N2VXdlVBay8waUxtMnY3Wk1CWUF2TmFDamVOd3BNNjJmCmpBVnd2YVBid0lIRGZBZHdRaU42bHhrbThIWHlsV0xEZDVnTEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCVEYKL0VFcGdsVGJOZ1VTYnhTS2c1bk1kMzMyZ3pBZkJnTlZIU01FR0RBV2dCVEYvRUVwZ2xUYk5nVVNieFNLZzVuTQpkMzMyZ3pBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCWTN5MWI0MC9sCm03bVJrek91YnRFSnNYWWUzYTFSYkx0eE4vNnQzOG1kNnlneWxVVzZ5WWxJTHBYdjc1ZlFIR3Z2cUhMREdJdmMKOG5VVCsrNUgrUHExaHZxeVV3azFUby9NODE2NkNDMHB2UVNERERMMkNYUzl5TWtrL25tQXBTV2l5aVhRT0cxRApyWEdSMk9BZFlYcFdaNHlzZFRqSGNCY2V1Z3Y0ZzJGOWtXSXJ1eDBCeExGdzE4YjVqSGI1dTltK1VnMDZZMTd6ClNxbWhza0dYajVLWTkwWXAwZUpnUHBWRjNPSzhIWGRYbVlTcjdjOXp4bWc1NGR4K0QxcnMveUc1SjJBN1NTU3gKM1BnL05zbXZvY2QzdFp3K1ZyUnkycC9GbXZ4aUdQOHM0MFBQMTVjdkZMcnM0REVZRFVtekxXNmtqVW9aK041bgpiZFFGM24rZ045ZnkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    service:
+      name: openfunction-webhook-service
+      namespace: openfunction
+      path: /mutate-core-openfunction-io-v1beta1-serving
+  failurePolicy: Fail
+  name: mservings.of.io
+  rules:
+  - apiGroups:
+    - core.openfunction.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - servings
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUROVENDQWgyZ0F3SUJBZ0lVUWNCUGt6MC90OTZ2dzJZV2F0S1JqRWZwaFJrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0tqRW9NQ1lHQTFVRUF3d2ZZMkV0YjNCbGJtWjFibU4wYVc5dUxYZGxZbWh2YjJzdGMyVnlkbWxqWlRBZQpGdzB5TWpBME1EY3dNelV3TURaYUZ3MHpNakEwTURRd016VXdNRFphTUNveEtEQW1CZ05WQkFNTUgyTmhMVzl3ClpXNW1kVzVqZEdsdmJpMTNaV0pvYjI5ckxYTmxjblpwWTJVd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUIKRHdBd2dnRUtBb0lCQVFEVXpZK1hZSmoxdS9sNmZvR1NiWEhaUDNhZklZN1lFRi9ZUk9sQ1V0Q2VBZ25CSDE4NwpqUk1hUVlTWmxMQTBBNEUxR0ZONzVqUU5KV3k5MVJkZmsxN1Z3RFlSa2lpUmg4bjNJbHpsbHQrQ3JKdWJsUHJmCkRFUVZuUkNTRW1Udnc5WmIvWkpXSXloRTNmN0dhckY4S3R3VVZXazNzTzB2Mk0wWXVvdGQxdjdUV3JmS0FBaUgKQjhNS0E2VTN6M0gyOSs0M1NkN1I5SW8vQzhuSFVHMkUrMDk5R3lhcnhRNUVkb2hkTkVCc05jbGprS0ZkNDRkKwpTdzRSVG56MFhIS1JILy9TM0hQMmUvd1ptRTBkb2E0N2VXdlVBay8waUxtMnY3Wk1CWUF2TmFDamVOd3BNNjJmCmpBVnd2YVBid0lIRGZBZHdRaU42bHhrbThIWHlsV0xEZDVnTEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCVEYKL0VFcGdsVGJOZ1VTYnhTS2c1bk1kMzMyZ3pBZkJnTlZIU01FR0RBV2dCVEYvRUVwZ2xUYk5nVVNieFNLZzVuTQpkMzMyZ3pBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCWTN5MWI0MC9sCm03bVJrek91YnRFSnNYWWUzYTFSYkx0eE4vNnQzOG1kNnlneWxVVzZ5WWxJTHBYdjc1ZlFIR3Z2cUhMREdJdmMKOG5VVCsrNUgrUHExaHZxeVV3azFUby9NODE2NkNDMHB2UVNERERMMkNYUzl5TWtrL25tQXBTV2l5aVhRT0cxRApyWEdSMk9BZFlYcFdaNHlzZFRqSGNCY2V1Z3Y0ZzJGOWtXSXJ1eDBCeExGdzE4YjVqSGI1dTltK1VnMDZZMTd6ClNxbWhza0dYajVLWTkwWXAwZUpnUHBWRjNPSzhIWGRYbVlTcjdjOXp4bWc1NGR4K0QxcnMveUc1SjJBN1NTU3gKM1BnL05zbXZvY2QzdFp3K1ZyUnkycC9GbXZ4aUdQOHM0MFBQMTVjdkZMcnM0REVZRFVtekxXNmtqVW9aK041bgpiZFFGM24rZ045ZnkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    service:
+      name: openfunction-webhook-service
+      namespace: openfunction
+      path: /mutate-networking-openfunction-io-v1alpha1-gateway
+  failurePolicy: Fail
+  name: mgateway.of.io
+  rules:
+  - apiGroups:
+    - networking.openfunction.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: openfunction-validating-webhook-configuration
+  namespace: openfunction
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUROVENDQWgyZ0F3SUJBZ0lVUWNCUGt6MC90OTZ2dzJZV2F0S1JqRWZwaFJrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0tqRW9NQ1lHQTFVRUF3d2ZZMkV0YjNCbGJtWjFibU4wYVc5dUxYZGxZbWh2YjJzdGMyVnlkbWxqWlRBZQpGdzB5TWpBME1EY3dNelV3TURaYUZ3MHpNakEwTURRd016VXdNRFphTUNveEtEQW1CZ05WQkFNTUgyTmhMVzl3ClpXNW1kVzVqZEdsdmJpMTNaV0pvYjI5ckxYTmxjblpwWTJVd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUIKRHdBd2dnRUtBb0lCQVFEVXpZK1hZSmoxdS9sNmZvR1NiWEhaUDNhZklZN1lFRi9ZUk9sQ1V0Q2VBZ25CSDE4NwpqUk1hUVlTWmxMQTBBNEUxR0ZONzVqUU5KV3k5MVJkZmsxN1Z3RFlSa2lpUmg4bjNJbHpsbHQrQ3JKdWJsUHJmCkRFUVZuUkNTRW1Udnc5WmIvWkpXSXloRTNmN0dhckY4S3R3VVZXazNzTzB2Mk0wWXVvdGQxdjdUV3JmS0FBaUgKQjhNS0E2VTN6M0gyOSs0M1NkN1I5SW8vQzhuSFVHMkUrMDk5R3lhcnhRNUVkb2hkTkVCc05jbGprS0ZkNDRkKwpTdzRSVG56MFhIS1JILy9TM0hQMmUvd1ptRTBkb2E0N2VXdlVBay8waUxtMnY3Wk1CWUF2TmFDamVOd3BNNjJmCmpBVnd2YVBid0lIRGZBZHdRaU42bHhrbThIWHlsV0xEZDVnTEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCVEYKL0VFcGdsVGJOZ1VTYnhTS2c1bk1kMzMyZ3pBZkJnTlZIU01FR0RBV2dCVEYvRUVwZ2xUYk5nVVNieFNLZzVuTQpkMzMyZ3pBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCWTN5MWI0MC9sCm03bVJrek91YnRFSnNYWWUzYTFSYkx0eE4vNnQzOG1kNnlneWxVVzZ5WWxJTHBYdjc1ZlFIR3Z2cUhMREdJdmMKOG5VVCsrNUgrUHExaHZxeVV3azFUby9NODE2NkNDMHB2UVNERERMMkNYUzl5TWtrL25tQXBTV2l5aVhRT0cxRApyWEdSMk9BZFlYcFdaNHlzZFRqSGNCY2V1Z3Y0ZzJGOWtXSXJ1eDBCeExGdzE4YjVqSGI1dTltK1VnMDZZMTd6ClNxbWhza0dYajVLWTkwWXAwZUpnUHBWRjNPSzhIWGRYbVlTcjdjOXp4bWc1NGR4K0QxcnMveUc1SjJBN1NTU3gKM1BnL05zbXZvY2QzdFp3K1ZyUnkycC9GbXZ4aUdQOHM0MFBQMTVjdkZMcnM0REVZRFVtekxXNmtqVW9aK041bgpiZFFGM24rZ045ZnkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    service:
+      name: openfunction-webhook-service
+      namespace: openfunction
+      path: /validate-core-openfunction-io-v1beta1-function
+  failurePolicy: Fail
+  name: vfunctions.of.io
+  rules:
+  - apiGroups:
+    - core.openfunction.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - functions
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUROVENDQWgyZ0F3SUJBZ0lVUWNCUGt6MC90OTZ2dzJZV2F0S1JqRWZwaFJrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0tqRW9NQ1lHQTFVRUF3d2ZZMkV0YjNCbGJtWjFibU4wYVc5dUxYZGxZbWh2YjJzdGMyVnlkbWxqWlRBZQpGdzB5TWpBME1EY3dNelV3TURaYUZ3MHpNakEwTURRd016VXdNRFphTUNveEtEQW1CZ05WQkFNTUgyTmhMVzl3ClpXNW1kVzVqZEdsdmJpMTNaV0pvYjI5ckxYTmxjblpwWTJVd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUIKRHdBd2dnRUtBb0lCQVFEVXpZK1hZSmoxdS9sNmZvR1NiWEhaUDNhZklZN1lFRi9ZUk9sQ1V0Q2VBZ25CSDE4NwpqUk1hUVlTWmxMQTBBNEUxR0ZONzVqUU5KV3k5MVJkZmsxN1Z3RFlSa2lpUmg4bjNJbHpsbHQrQ3JKdWJsUHJmCkRFUVZuUkNTRW1Udnc5WmIvWkpXSXloRTNmN0dhckY4S3R3VVZXazNzTzB2Mk0wWXVvdGQxdjdUV3JmS0FBaUgKQjhNS0E2VTN6M0gyOSs0M1NkN1I5SW8vQzhuSFVHMkUrMDk5R3lhcnhRNUVkb2hkTkVCc05jbGprS0ZkNDRkKwpTdzRSVG56MFhIS1JILy9TM0hQMmUvd1ptRTBkb2E0N2VXdlVBay8waUxtMnY3Wk1CWUF2TmFDamVOd3BNNjJmCmpBVnd2YVBid0lIRGZBZHdRaU42bHhrbThIWHlsV0xEZDVnTEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCVEYKL0VFcGdsVGJOZ1VTYnhTS2c1bk1kMzMyZ3pBZkJnTlZIU01FR0RBV2dCVEYvRUVwZ2xUYk5nVVNieFNLZzVuTQpkMzMyZ3pBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCWTN5MWI0MC9sCm03bVJrek91YnRFSnNYWWUzYTFSYkx0eE4vNnQzOG1kNnlneWxVVzZ5WWxJTHBYdjc1ZlFIR3Z2cUhMREdJdmMKOG5VVCsrNUgrUHExaHZxeVV3azFUby9NODE2NkNDMHB2UVNERERMMkNYUzl5TWtrL25tQXBTV2l5aVhRT0cxRApyWEdSMk9BZFlYcFdaNHlzZFRqSGNCY2V1Z3Y0ZzJGOWtXSXJ1eDBCeExGdzE4YjVqSGI1dTltK1VnMDZZMTd6ClNxbWhza0dYajVLWTkwWXAwZUpnUHBWRjNPSzhIWGRYbVlTcjdjOXp4bWc1NGR4K0QxcnMveUc1SjJBN1NTU3gKM1BnL05zbXZvY2QzdFp3K1ZyUnkycC9GbXZ4aUdQOHM0MFBQMTVjdkZMcnM0REVZRFVtekxXNmtqVW9aK041bgpiZFFGM24rZ045ZnkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    service:
+      name: openfunction-webhook-service
+      namespace: openfunction
+      path: /validate-networking-openfunction-io-v1alpha1-gateway
+  failurePolicy: Fail
+  name: vgateway.of.io
+  rules:
+  - apiGroups:
+    - networking.openfunction.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+  sideEffects: None
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -15943,6 +16064,16 @@ spec:
     spec:
       containers:
       - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: openfunction/kube-rbac-proxy:v0.8.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+      - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
@@ -15979,16 +16110,6 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
-      - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=10
-        image: openfunction/kube-rbac-proxy:v0.8.0
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
       securityContext:
         runAsNonRoot: true
       serviceAccountName: openfunction-controller-manager
@@ -15998,125 +16119,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: openfunction-webhook-server-cert
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: openfunction-mutating-webhook-configuration
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUROVENDQWgyZ0F3SUJBZ0lVUWNCUGt6MC90OTZ2dzJZV2F0S1JqRWZwaFJrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0tqRW9NQ1lHQTFVRUF3d2ZZMkV0YjNCbGJtWjFibU4wYVc5dUxYZGxZbWh2YjJzdGMyVnlkbWxqWlRBZQpGdzB5TWpBME1EY3dNelV3TURaYUZ3MHpNakEwTURRd016VXdNRFphTUNveEtEQW1CZ05WQkFNTUgyTmhMVzl3ClpXNW1kVzVqZEdsdmJpMTNaV0pvYjI5ckxYTmxjblpwWTJVd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUIKRHdBd2dnRUtBb0lCQVFEVXpZK1hZSmoxdS9sNmZvR1NiWEhaUDNhZklZN1lFRi9ZUk9sQ1V0Q2VBZ25CSDE4NwpqUk1hUVlTWmxMQTBBNEUxR0ZONzVqUU5KV3k5MVJkZmsxN1Z3RFlSa2lpUmg4bjNJbHpsbHQrQ3JKdWJsUHJmCkRFUVZuUkNTRW1Udnc5WmIvWkpXSXloRTNmN0dhckY4S3R3VVZXazNzTzB2Mk0wWXVvdGQxdjdUV3JmS0FBaUgKQjhNS0E2VTN6M0gyOSs0M1NkN1I5SW8vQzhuSFVHMkUrMDk5R3lhcnhRNUVkb2hkTkVCc05jbGprS0ZkNDRkKwpTdzRSVG56MFhIS1JILy9TM0hQMmUvd1ptRTBkb2E0N2VXdlVBay8waUxtMnY3Wk1CWUF2TmFDamVOd3BNNjJmCmpBVnd2YVBid0lIRGZBZHdRaU42bHhrbThIWHlsV0xEZDVnTEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCVEYKL0VFcGdsVGJOZ1VTYnhTS2c1bk1kMzMyZ3pBZkJnTlZIU01FR0RBV2dCVEYvRUVwZ2xUYk5nVVNieFNLZzVuTQpkMzMyZ3pBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCWTN5MWI0MC9sCm03bVJrek91YnRFSnNYWWUzYTFSYkx0eE4vNnQzOG1kNnlneWxVVzZ5WWxJTHBYdjc1ZlFIR3Z2cUhMREdJdmMKOG5VVCsrNUgrUHExaHZxeVV3azFUby9NODE2NkNDMHB2UVNERERMMkNYUzl5TWtrL25tQXBTV2l5aVhRT0cxRApyWEdSMk9BZFlYcFdaNHlzZFRqSGNCY2V1Z3Y0ZzJGOWtXSXJ1eDBCeExGdzE4YjVqSGI1dTltK1VnMDZZMTd6ClNxbWhza0dYajVLWTkwWXAwZUpnUHBWRjNPSzhIWGRYbVlTcjdjOXp4bWc1NGR4K0QxcnMveUc1SjJBN1NTU3gKM1BnL05zbXZvY2QzdFp3K1ZyUnkycC9GbXZ4aUdQOHM0MFBQMTVjdkZMcnM0REVZRFVtekxXNmtqVW9aK041bgpiZFFGM24rZ045ZnkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-    service:
-      name: openfunction-webhook-service
-      namespace: openfunction
-      path: /mutate-core-openfunction-io-v1beta1-function
-  failurePolicy: Fail
-  name: mfunctions.of.io
-  rules:
-  - apiGroups:
-    - core.openfunction.io
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - functions
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUROVENDQWgyZ0F3SUJBZ0lVUWNCUGt6MC90OTZ2dzJZV2F0S1JqRWZwaFJrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0tqRW9NQ1lHQTFVRUF3d2ZZMkV0YjNCbGJtWjFibU4wYVc5dUxYZGxZbWh2YjJzdGMyVnlkbWxqWlRBZQpGdzB5TWpBME1EY3dNelV3TURaYUZ3MHpNakEwTURRd016VXdNRFphTUNveEtEQW1CZ05WQkFNTUgyTmhMVzl3ClpXNW1kVzVqZEdsdmJpMTNaV0pvYjI5ckxYTmxjblpwWTJVd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUIKRHdBd2dnRUtBb0lCQVFEVXpZK1hZSmoxdS9sNmZvR1NiWEhaUDNhZklZN1lFRi9ZUk9sQ1V0Q2VBZ25CSDE4NwpqUk1hUVlTWmxMQTBBNEUxR0ZONzVqUU5KV3k5MVJkZmsxN1Z3RFlSa2lpUmg4bjNJbHpsbHQrQ3JKdWJsUHJmCkRFUVZuUkNTRW1Udnc5WmIvWkpXSXloRTNmN0dhckY4S3R3VVZXazNzTzB2Mk0wWXVvdGQxdjdUV3JmS0FBaUgKQjhNS0E2VTN6M0gyOSs0M1NkN1I5SW8vQzhuSFVHMkUrMDk5R3lhcnhRNUVkb2hkTkVCc05jbGprS0ZkNDRkKwpTdzRSVG56MFhIS1JILy9TM0hQMmUvd1ptRTBkb2E0N2VXdlVBay8waUxtMnY3Wk1CWUF2TmFDamVOd3BNNjJmCmpBVnd2YVBid0lIRGZBZHdRaU42bHhrbThIWHlsV0xEZDVnTEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCVEYKL0VFcGdsVGJOZ1VTYnhTS2c1bk1kMzMyZ3pBZkJnTlZIU01FR0RBV2dCVEYvRUVwZ2xUYk5nVVNieFNLZzVuTQpkMzMyZ3pBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCWTN5MWI0MC9sCm03bVJrek91YnRFSnNYWWUzYTFSYkx0eE4vNnQzOG1kNnlneWxVVzZ5WWxJTHBYdjc1ZlFIR3Z2cUhMREdJdmMKOG5VVCsrNUgrUHExaHZxeVV3azFUby9NODE2NkNDMHB2UVNERERMMkNYUzl5TWtrL25tQXBTV2l5aVhRT0cxRApyWEdSMk9BZFlYcFdaNHlzZFRqSGNCY2V1Z3Y0ZzJGOWtXSXJ1eDBCeExGdzE4YjVqSGI1dTltK1VnMDZZMTd6ClNxbWhza0dYajVLWTkwWXAwZUpnUHBWRjNPSzhIWGRYbVlTcjdjOXp4bWc1NGR4K0QxcnMveUc1SjJBN1NTU3gKM1BnL05zbXZvY2QzdFp3K1ZyUnkycC9GbXZ4aUdQOHM0MFBQMTVjdkZMcnM0REVZRFVtekxXNmtqVW9aK041bgpiZFFGM24rZ045ZnkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-    service:
-      name: openfunction-webhook-service
-      namespace: openfunction
-      path: /mutate-core-openfunction-io-v1beta1-serving
-  failurePolicy: Fail
-  name: mservings.of.io
-  rules:
-  - apiGroups:
-    - core.openfunction.io
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - servings
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUROVENDQWgyZ0F3SUJBZ0lVUWNCUGt6MC90OTZ2dzJZV2F0S1JqRWZwaFJrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0tqRW9NQ1lHQTFVRUF3d2ZZMkV0YjNCbGJtWjFibU4wYVc5dUxYZGxZbWh2YjJzdGMyVnlkbWxqWlRBZQpGdzB5TWpBME1EY3dNelV3TURaYUZ3MHpNakEwTURRd016VXdNRFphTUNveEtEQW1CZ05WQkFNTUgyTmhMVzl3ClpXNW1kVzVqZEdsdmJpMTNaV0pvYjI5ckxYTmxjblpwWTJVd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUIKRHdBd2dnRUtBb0lCQVFEVXpZK1hZSmoxdS9sNmZvR1NiWEhaUDNhZklZN1lFRi9ZUk9sQ1V0Q2VBZ25CSDE4NwpqUk1hUVlTWmxMQTBBNEUxR0ZONzVqUU5KV3k5MVJkZmsxN1Z3RFlSa2lpUmg4bjNJbHpsbHQrQ3JKdWJsUHJmCkRFUVZuUkNTRW1Udnc5WmIvWkpXSXloRTNmN0dhckY4S3R3VVZXazNzTzB2Mk0wWXVvdGQxdjdUV3JmS0FBaUgKQjhNS0E2VTN6M0gyOSs0M1NkN1I5SW8vQzhuSFVHMkUrMDk5R3lhcnhRNUVkb2hkTkVCc05jbGprS0ZkNDRkKwpTdzRSVG56MFhIS1JILy9TM0hQMmUvd1ptRTBkb2E0N2VXdlVBay8waUxtMnY3Wk1CWUF2TmFDamVOd3BNNjJmCmpBVnd2YVBid0lIRGZBZHdRaU42bHhrbThIWHlsV0xEZDVnTEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCVEYKL0VFcGdsVGJOZ1VTYnhTS2c1bk1kMzMyZ3pBZkJnTlZIU01FR0RBV2dCVEYvRUVwZ2xUYk5nVVNieFNLZzVuTQpkMzMyZ3pBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCWTN5MWI0MC9sCm03bVJrek91YnRFSnNYWWUzYTFSYkx0eE4vNnQzOG1kNnlneWxVVzZ5WWxJTHBYdjc1ZlFIR3Z2cUhMREdJdmMKOG5VVCsrNUgrUHExaHZxeVV3azFUby9NODE2NkNDMHB2UVNERERMMkNYUzl5TWtrL25tQXBTV2l5aVhRT0cxRApyWEdSMk9BZFlYcFdaNHlzZFRqSGNCY2V1Z3Y0ZzJGOWtXSXJ1eDBCeExGdzE4YjVqSGI1dTltK1VnMDZZMTd6ClNxbWhza0dYajVLWTkwWXAwZUpnUHBWRjNPSzhIWGRYbVlTcjdjOXp4bWc1NGR4K0QxcnMveUc1SjJBN1NTU3gKM1BnL05zbXZvY2QzdFp3K1ZyUnkycC9GbXZ4aUdQOHM0MFBQMTVjdkZMcnM0REVZRFVtekxXNmtqVW9aK041bgpiZFFGM24rZ045ZnkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-    service:
-      name: openfunction-webhook-service
-      namespace: openfunction
-      path: /mutate-networking-openfunction-io-v1alpha1-gateway
-  failurePolicy: Fail
-  name: mgateway.of.io
-  rules:
-  - apiGroups:
-    - networking.openfunction.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-  sideEffects: None
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: openfunction-validating-webhook-configuration
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUROVENDQWgyZ0F3SUJBZ0lVUWNCUGt6MC90OTZ2dzJZV2F0S1JqRWZwaFJrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0tqRW9NQ1lHQTFVRUF3d2ZZMkV0YjNCbGJtWjFibU4wYVc5dUxYZGxZbWh2YjJzdGMyVnlkbWxqWlRBZQpGdzB5TWpBME1EY3dNelV3TURaYUZ3MHpNakEwTURRd016VXdNRFphTUNveEtEQW1CZ05WQkFNTUgyTmhMVzl3ClpXNW1kVzVqZEdsdmJpMTNaV0pvYjI5ckxYTmxjblpwWTJVd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUIKRHdBd2dnRUtBb0lCQVFEVXpZK1hZSmoxdS9sNmZvR1NiWEhaUDNhZklZN1lFRi9ZUk9sQ1V0Q2VBZ25CSDE4NwpqUk1hUVlTWmxMQTBBNEUxR0ZONzVqUU5KV3k5MVJkZmsxN1Z3RFlSa2lpUmg4bjNJbHpsbHQrQ3JKdWJsUHJmCkRFUVZuUkNTRW1Udnc5WmIvWkpXSXloRTNmN0dhckY4S3R3VVZXazNzTzB2Mk0wWXVvdGQxdjdUV3JmS0FBaUgKQjhNS0E2VTN6M0gyOSs0M1NkN1I5SW8vQzhuSFVHMkUrMDk5R3lhcnhRNUVkb2hkTkVCc05jbGprS0ZkNDRkKwpTdzRSVG56MFhIS1JILy9TM0hQMmUvd1ptRTBkb2E0N2VXdlVBay8waUxtMnY3Wk1CWUF2TmFDamVOd3BNNjJmCmpBVnd2YVBid0lIRGZBZHdRaU42bHhrbThIWHlsV0xEZDVnTEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCVEYKL0VFcGdsVGJOZ1VTYnhTS2c1bk1kMzMyZ3pBZkJnTlZIU01FR0RBV2dCVEYvRUVwZ2xUYk5nVVNieFNLZzVuTQpkMzMyZ3pBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCWTN5MWI0MC9sCm03bVJrek91YnRFSnNYWWUzYTFSYkx0eE4vNnQzOG1kNnlneWxVVzZ5WWxJTHBYdjc1ZlFIR3Z2cUhMREdJdmMKOG5VVCsrNUgrUHExaHZxeVV3azFUby9NODE2NkNDMHB2UVNERERMMkNYUzl5TWtrL25tQXBTV2l5aVhRT0cxRApyWEdSMk9BZFlYcFdaNHlzZFRqSGNCY2V1Z3Y0ZzJGOWtXSXJ1eDBCeExGdzE4YjVqSGI1dTltK1VnMDZZMTd6ClNxbWhza0dYajVLWTkwWXAwZUpnUHBWRjNPSzhIWGRYbVlTcjdjOXp4bWc1NGR4K0QxcnMveUc1SjJBN1NTU3gKM1BnL05zbXZvY2QzdFp3K1ZyUnkycC9GbXZ4aUdQOHM0MFBQMTVjdkZMcnM0REVZRFVtekxXNmtqVW9aK041bgpiZFFGM24rZ045ZnkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-    service:
-      name: openfunction-webhook-service
-      namespace: openfunction
-      path: /validate-core-openfunction-io-v1beta1-function
-  failurePolicy: Fail
-  name: vfunctions.of.io
-  rules:
-  - apiGroups:
-    - core.openfunction.io
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - functions
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUROVENDQWgyZ0F3SUJBZ0lVUWNCUGt6MC90OTZ2dzJZV2F0S1JqRWZwaFJrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0tqRW9NQ1lHQTFVRUF3d2ZZMkV0YjNCbGJtWjFibU4wYVc5dUxYZGxZbWh2YjJzdGMyVnlkbWxqWlRBZQpGdzB5TWpBME1EY3dNelV3TURaYUZ3MHpNakEwTURRd016VXdNRFphTUNveEtEQW1CZ05WQkFNTUgyTmhMVzl3ClpXNW1kVzVqZEdsdmJpMTNaV0pvYjI5ckxYTmxjblpwWTJVd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUIKRHdBd2dnRUtBb0lCQVFEVXpZK1hZSmoxdS9sNmZvR1NiWEhaUDNhZklZN1lFRi9ZUk9sQ1V0Q2VBZ25CSDE4NwpqUk1hUVlTWmxMQTBBNEUxR0ZONzVqUU5KV3k5MVJkZmsxN1Z3RFlSa2lpUmg4bjNJbHpsbHQrQ3JKdWJsUHJmCkRFUVZuUkNTRW1Udnc5WmIvWkpXSXloRTNmN0dhckY4S3R3VVZXazNzTzB2Mk0wWXVvdGQxdjdUV3JmS0FBaUgKQjhNS0E2VTN6M0gyOSs0M1NkN1I5SW8vQzhuSFVHMkUrMDk5R3lhcnhRNUVkb2hkTkVCc05jbGprS0ZkNDRkKwpTdzRSVG56MFhIS1JILy9TM0hQMmUvd1ptRTBkb2E0N2VXdlVBay8waUxtMnY3Wk1CWUF2TmFDamVOd3BNNjJmCmpBVnd2YVBid0lIRGZBZHdRaU42bHhrbThIWHlsV0xEZDVnTEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCVEYKL0VFcGdsVGJOZ1VTYnhTS2c1bk1kMzMyZ3pBZkJnTlZIU01FR0RBV2dCVEYvRUVwZ2xUYk5nVVNieFNLZzVuTQpkMzMyZ3pBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCWTN5MWI0MC9sCm03bVJrek91YnRFSnNYWWUzYTFSYkx0eE4vNnQzOG1kNnlneWxVVzZ5WWxJTHBYdjc1ZlFIR3Z2cUhMREdJdmMKOG5VVCsrNUgrUHExaHZxeVV3azFUby9NODE2NkNDMHB2UVNERERMMkNYUzl5TWtrL25tQXBTV2l5aVhRT0cxRApyWEdSMk9BZFlYcFdaNHlzZFRqSGNCY2V1Z3Y0ZzJGOWtXSXJ1eDBCeExGdzE4YjVqSGI1dTltK1VnMDZZMTd6ClNxbWhza0dYajVLWTkwWXAwZUpnUHBWRjNPSzhIWGRYbVlTcjdjOXp4bWc1NGR4K0QxcnMveUc1SjJBN1NTU3gKM1BnL05zbXZvY2QzdFp3K1ZyUnkycC9GbXZ4aUdQOHM0MFBQMTVjdkZMcnM0REVZRFVtekxXNmtqVW9aK041bgpiZFFGM24rZ045ZnkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-    service:
-      name: openfunction-webhook-service
-      namespace: openfunction
-      path: /validate-networking-openfunction-io-v1alpha1-gateway
-  failurePolicy: Fail
-  name: vgateway.of.io
-  rules:
-  - apiGroups:
-    - networking.openfunction.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-  sideEffects: None
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -16184,3 +16186,9 @@ data:
       # W3C Baggage Specification/: https://w3c.github.io/baggage/
         key: sw8-correlation # key should be baggage for opentelemetry
         value: "base64(string key):base64(string value),base64(string key2):base64(string value2)"
+    # Config OpenFunction eventsource handler image repo
+    openfunction.eventsource-handler.image: "openfunction/eventsource-handler:v4"
+    # Config OpenFunction trigger handler image repo
+    openfunction.trigger-handler.image: "openfunction/trigger-handler:v4"
+    # Config OpenFunction dapr-proxy image repo
+    openfunction.dapr-proxy.image: "openfunction/dapr-proxy:v0.1.0"

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -22,9 +22,10 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
-	"github.com/openfunction/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openfunction/pkg/constants"
 )
 
 func InterfaceIsNil(val interface{}) bool {


### PR DESCRIPTION
Signed-off-by: xjl123456 <1576696610@qq.com>

There is no sink when creating the EventSource crd

```
apiVersion: events.openfunction.io/v1alpha1
kind: EventSource
metadata:
  name: my-eventsource
spec:
  logLevel: "2"
  cron:
    default-cron:
      schedule: '@every 5s'
  eventBus: default
```
openfunction controller error
```
2022-12-14T02:20:26.733Z        INFO    controllers.EventSource Updated status on EventSource   {"EventSource": "xjl/my-eventsource", "resource version": "4943504"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x16fcb75]

goroutine 1029 [running]:
github.com/openfunction/controllers/events.(*EventSourceReconciler).createOrUpdateEventSource(0xc0003b4f00, 0x1cc29b8, 0xc0008fafc0, 0x1ccc760, 0xc0008f7b30, 0xc0008ea480, 0x0, 0x0)
        /workspace/controllers/events/eventsource_controller.go:175 +0x355
github.com/openfunction/controllers/events.(*EventSourceReconciler).Reconcile(0xc0003b4f00, 0x1cc29b8, 0xc0008fafc0, 0xc0003fb66d, 0x3, 0xc0003fb670, 0xe, 0xc0008fafc0, 0xc000bde000, 0x1927cc0, ...)
        /workspace/controllers/events/eventsource_controller.go:104 +0x436
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0004f6aa0, 0x1cc2910, 0xc0008805c0, 0x18e1c40, 0xc000561c80)
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.7/pkg/internal/controller/controller.go:298 +0x30d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0004f6aa0, 0x1cc2910, 0xc0008805c0, 0xc00099f700)
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.7/pkg/internal/controller/controller.go:253 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2(0xc0000ba750, 0xc0004f6aa0, 0x1cc2910, 0xc0008805c0)
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.7/pkg/internal/controller/controller.go:214 +0x6b
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.7/pkg/internal/controller/controller.go:210 +0x425
```


