### PR TITLE
set scopes when create dapr components

### DIFF
--- a/pkg/core/serving/common/common.go
+++ b/pkg/core/serving/common/common.go
@@ -271,6 +271,7 @@ func CreateComponents(
 					ServingLabel:        s.Name,
 				},
 			},
+			Scopes: []string{fmt.Sprintf("%s-%s", GetFunctionName(s), s.Namespace)},
 		}
 
 		if dc != nil {


### PR DESCRIPTION

Set the scope of the dapr component when creating it, so that the dapr component can only be accessed by function.