### PR TITLE
Fix some yaml files and md documents still remain core in v1beta1 format

### DIFF
--- a/docs/concepts/OpenFunction-events-framework.md
+++ b/docs/concepts/OpenFunction-events-framework.md
@@ -76,7 +76,7 @@ In this sample, the event source is a Kafka server and the target function is a 
   You can create a function like below as the EventSource Sink.
 
   ```yaml
-  apiVersion: core.openfunction.io/v1beta1
+  apiVersion: core.openfunction.io/v1beta2
   kind: Function
   metadata:
     name: sink
@@ -164,7 +164,7 @@ At this point we see that the target function is not started (because there is n
 Create an event producer `events-producer.yaml`:
 
 ```yaml
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: events-producer
@@ -235,7 +235,7 @@ serving-4x5wh-ksvc-wxbf2-v100-deployment-5c495c84f6-8n6mk      2/2     Running  
   You can create a function like below as the target function to trigger:
 
   ```yaml
-  apiVersion: core.openfunction.io/v1beta1
+  apiVersion: core.openfunction.io/v1beta2
   kind: Function
   metadata:
     name: sink
@@ -282,7 +282,7 @@ serving-4x5wh-ksvc-wxbf2-v100-deployment-5c495c84f6-8n6mk      2/2     Running  
   We create an Async function that is triggered by the Trigger and prints the received message:
 
   ```yaml
-  apiVersion: core.openfunction.io/v1beta1
+  apiVersion: core.openfunction.io/v1beta2
   kind: Function
   metadata:
     name: trigger-target

--- a/docs/proposals/202207-openfunction-gateway.md
+++ b/docs/proposals/202207-openfunction-gateway.md
@@ -18,7 +18,7 @@ Since the domain will be deprecated, the following resources will be removed:
 - The Domain-related logic will be removed
 - The `OpenFunction/config/domain/default-domain.yaml` will be removed
 ```yaml=
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Domain
 metadata:
   name: openfunction
@@ -315,7 +315,7 @@ Whenever a function is created, the function controller will:
 - Create service `{{.Name}}.{{.Namespace}}.svc.cluster.local`, the service will create a cname to OpenFunction gateway. This address will be used as function internal address
 
 ```yaml=
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: function-sample

--- a/docs/proposals/20220919-dapr-proxy.md
+++ b/docs/proposals/20220919-dapr-proxy.md
@@ -30,7 +30,7 @@ created, the function controller will:
 - Create Function Service to accept event(for async functions).
 
 ```yaml
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: sink

--- a/docs/proposals/20230223-wasmedge-integration.md
+++ b/docs/proposals/20230223-wasmedge-integration.md
@@ -84,7 +84,7 @@ When the value of the `spec.workloadRuntime` field is `wasmedge` or the annotati
 
 
 ```yaml=
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: wasmedge-http-server-build
@@ -137,7 +137,7 @@ When the value of the `spec.workloadRuntime` field is `wasmedge` or the annotati
 #### WASM cases in Knative Serving
 
 ```yaml=
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: wasmedge-http-server-serving

--- a/docs/proposals/20230330-support-dapr-state-management.md
+++ b/docs/proposals/20230330-support-dapr-state-management.md
@@ -34,7 +34,7 @@ When you define `spec.serving.states` in Function CR, the controller will do the
 - Generate states relevant context to the `FUNC_CONTEXT` env var
 
 ```yaml
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: state-function-sample

--- a/test/async-runtime/bindings/manifests.yaml
+++ b/test/async-runtime/bindings/manifests.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: e2e-v1beta1-kafka-input
@@ -84,7 +84,7 @@ spec:
         - name: function
           imagePullPolicy: Always
 ---
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: e2e-v1beta1-cron-in-kafka-out

--- a/test/async-runtime/pubsub/manifests.yaml
+++ b/test/async-runtime/pubsub/manifests.yaml
@@ -69,7 +69,7 @@ spec:
     - name: allowedTopics
       value: "pubsub"
 ---
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: e2e-v1beta1-subscriber

--- a/test/events/manifests.yaml
+++ b/test/events/manifests.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: e2e-v1beta1-cron-in-kafka-out
@@ -67,7 +67,7 @@ spec:
           - name: authRequired
             value: "false"
 ---
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: sink-a
@@ -82,7 +82,7 @@ spec:
         - name: function
           imagePullPolicy: Always
 ---
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: sink-b

--- a/test/knative-runtime/knative-dapr/manifests.yaml
+++ b/test/knative-runtime/knative-dapr/manifests.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: e2e-v1beta1-kafka-input
@@ -84,7 +84,7 @@ spec:
         - name: function
           imagePullPolicy: Always
 ---
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: e2e-v1beta1-function-front

--- a/test/knative-runtime/knative/manifests.yaml
+++ b/test/knative-runtime/knative/manifests.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: e2e-v1beta1-knative

--- a/test/plugin/manifests.yaml
+++ b/test/plugin/manifests.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-apiVersion: core.openfunction.io/v1beta1
+apiVersion: core.openfunction.io/v1beta2
 kind: Function
 metadata:
   name: e2e-v1beta1-plugins


### PR DESCRIPTION
Starting from version v1.1.0, the core v1beta1 API is deprecated and will be removed in the future. However, in some YAML files and md documents, there are still remain in v1beta1 format.

Fixes: #520