### PR TITLE
gateway: inherent annotations and labels

### DIFF
--- a/controllers/networking/gateway_controller.go
+++ b/controllers/networking/gateway_controller.go
@@ -277,6 +277,7 @@ func (r *GatewayReconciler) reconcileK8sGateway(gateway *networkingv1alpha1.Gate
 		r.k8sGateway.Annotations = make(map[string]string)
 	}
 	r.k8sGateway.Annotations[networkingv1alpha1.GatewayListenersAnnotation] = string(listenersAnnotation)
+	r.k8sGateway.Labels = gateway.Labels
 
 	for k, v := range gateway.Annotations {
 		r.k8sGateway.Annotations[k] = v


### PR DESCRIPTION
 Gateway.gateway.networking.k8s.io inherent annotations and labels from Gateway.networking.openfunction.io, and then 
> Annotations and labels on the  Gateway.gateway.networking.k8s.io will be copied to the Service and Deployment. This allows configuring things such as [Internal load balancers](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer) that read from these fields.

https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/#automated-deployment